### PR TITLE
feat: board settings, WIP limits, waitForApproval tool, agent team mode

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "moe": {
+      "command": "node",
+      "env": {
+        "MOE_PROJECT_PATH": "/Users/omrihaviv/IdeaProjects/Moe-s-Tavern"
+      },
+      "args": [
+        "/Users/omrihaviv/IdeaProjects/Moe-s-Tavern/packages/moe-proxy/dist/index.js"
+      ]
+    }
+  }
+}

--- a/.moe/project.json
+++ b/.moe/project.json
@@ -30,11 +30,7 @@
     "branchPattern": "moe/epicId/taskId",
     "commitPattern": "featepicId: taskTitle",
     "agentCommand": "claude",
-    "enableAgentTeams": false,
-    "columnLimits": {},
-    "chatEnabled": true,
-    "chatMaxAgentHops": 4,
-    "chatAutoCreateChannels": true
+    "columnLimits": {}
   },
   "createdAt": "2026-02-03T11:19:51.668611800Z",
   "updatedAt": "2026-02-21T23:16:23.985Z"

--- a/moe-jetbrains/build.gradle.kts
+++ b/moe-jetbrains/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.moe"
-version = "0.1.0"
+version = "0.2.0"
 
 repositories {
     mavenCentral()

--- a/moe-jetbrains/src/main/kotlin/com/moe/model/Models.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/model/Models.kt
@@ -24,7 +24,9 @@ data class ProjectSettings(
     val commitPattern: String = "feat({epicId}): {taskTitle}",
     val agentCommand: String = "claude",
     val enableAgentTeams: Boolean = false,
-    val columnLimits: Map<String, Int>? = null
+    val columnLimits: Map<String, Int>? = null,
+    val columnAgents: Map<String, String>? = null,
+    val agentTeamMode: Boolean = false
 )
 
 data class Epic(

--- a/moe-jetbrains/src/main/kotlin/com/moe/services/MoeProjectService.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/services/MoeProjectService.kt
@@ -723,6 +723,17 @@ class MoeProjectService(private val project: IdeaProject) : Disposable {
             addProperty("commitPattern", settings.commitPattern)
             addProperty("agentCommand", settings.agentCommand)
             addProperty("enableAgentTeams", settings.enableAgentTeams)
+            settings.columnLimits?.let { limits ->
+                val limitsObj = JsonObject()
+                limits.forEach { (k, v) -> limitsObj.addProperty(k, v) }
+                add("columnLimits", limitsObj)
+            }
+            settings.columnAgents?.let { agents ->
+                val agentsObj = JsonObject()
+                agents.forEach { (k, v) -> agentsObj.addProperty(k, v) }
+                add("columnAgents", agentsObj)
+            }
+            addProperty("agentTeamMode", settings.agentTeamMode)
         }
         sendMessage("UPDATE_SETTINGS", payload)
     }

--- a/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/BoardSettingsPanel.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/BoardSettingsPanel.kt
@@ -1,0 +1,177 @@
+package com.moe.toolwindow
+
+import com.moe.model.MoeState
+import com.moe.model.ProjectSettings
+import com.moe.services.MoeProjectService
+import com.moe.services.MoeStateListener
+import com.moe.util.MoeBundle
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import javax.swing.DefaultCellEditor
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JSpinner
+import javax.swing.JTextField
+import javax.swing.SpinnerNumberModel
+import javax.swing.SwingUtilities
+import javax.swing.table.AbstractTableModel
+import javax.swing.table.TableCellEditor
+import javax.swing.table.TableCellRenderer
+import com.intellij.openapi.ui.ComboBox
+import javax.swing.DefaultComboBoxModel
+import java.awt.Component
+import javax.swing.JTable
+
+class BoardSettingsPanel(private val project: Project) : JBPanel<BoardSettingsPanel>(BorderLayout()), Disposable {
+    private val service = project.service<MoeProjectService>()
+    private val columns = listOf("BACKLOG", "PLANNING", "WORKING", "REVIEW", "DEPLOYING", "DONE")
+    private val agentRoles = arrayOf("(none)", "architect", "worker", "qa")
+
+    private val wipLimits = mutableMapOf<String, Int?>()
+    private val columnAgents = mutableMapOf<String, String?>()
+
+    private val tableModel = ColumnSettingsTableModel()
+    private val table = JBTable(tableModel)
+    private var stateListener: MoeStateListener? = null
+
+    init {
+        border = JBUI.Borders.empty(8)
+
+        table.apply {
+            setShowGrid(true)
+            rowHeight = 28
+            columnModel.getColumn(0).preferredWidth = 120
+            columnModel.getColumn(1).preferredWidth = 100
+            columnModel.getColumn(2).preferredWidth = 140
+
+            // WIP Limit column: editable text field (accepts blank for no limit)
+            columnModel.getColumn(1).cellEditor = object : DefaultCellEditor(JTextField()) {
+                override fun getCellEditorValue(): Any {
+                    val text = (component as JTextField).text.trim()
+                    return if (text.isEmpty()) "" else text
+                }
+            }
+
+            // Agent column: combo box editor
+            val agentCombo = ComboBox(agentRoles)
+            columnModel.getColumn(2).cellEditor = DefaultCellEditor(agentCombo)
+        }
+
+        val scrollPane = JBScrollPane(table)
+
+        val buttonPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 8, 4)).apply {
+            isOpaque = false
+            val saveButton = JButton(MoeBundle.message("moe.settings.save"))
+            saveButton.addActionListener { saveSettings() }
+            add(saveButton)
+        }
+
+        add(scrollPane, BorderLayout.CENTER)
+        add(buttonPanel, BorderLayout.SOUTH)
+
+        stateListener = object : MoeStateListener {
+            override fun onState(state: MoeState) {
+                SwingUtilities.invokeLater { loadFromState(state) }
+            }
+            override fun onStatus(connected: Boolean, message: String) {}
+        }
+        service.addListener(stateListener!!)
+
+        // Load initial state if available
+        service.getState()?.let { loadFromState(it) }
+    }
+
+    private fun loadFromState(state: MoeState) {
+        val settings = state.project.settings ?: return
+        wipLimits.clear()
+        columnAgents.clear()
+        for (col in columns) {
+            wipLimits[col] = settings.columnLimits?.get(col)
+            columnAgents[col] = settings.columnAgents?.get(col)
+        }
+        tableModel.fireTableDataChanged()
+    }
+
+    private fun saveSettings() {
+        val currentState = service.getState() ?: return
+        val currentSettings = currentState.project.settings ?: ProjectSettings()
+
+        val newLimits = mutableMapOf<String, Int>()
+        for (col in columns) {
+            wipLimits[col]?.let { newLimits[col] = it }
+        }
+
+        val newAgents = mutableMapOf<String, String>()
+        for (col in columns) {
+            columnAgents[col]?.let { newAgents[col] = it }
+        }
+
+        val updatedSettings = currentSettings.copy(
+            columnLimits = newLimits.ifEmpty { null },
+            columnAgents = newAgents.ifEmpty { null }
+        )
+        service.updateSettings(updatedSettings)
+
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("Moe Notifications")
+            .createNotification("Moe", MoeBundle.message("moe.settings.saved"), NotificationType.INFORMATION)
+            .notify(project)
+    }
+
+    override fun dispose() {
+        stateListener?.let { service.removeListener(it) }
+        stateListener = null
+    }
+
+    private inner class ColumnSettingsTableModel : AbstractTableModel() {
+        private val columnNames = arrayOf(
+            MoeBundle.message("moe.settings.columnName"),
+            MoeBundle.message("moe.settings.wipLimit"),
+            MoeBundle.message("moe.settings.assignedAgent")
+        )
+
+        override fun getRowCount(): Int = columns.size
+        override fun getColumnCount(): Int = columnNames.size
+        override fun getColumnName(column: Int): String = columnNames[column]
+
+        override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean {
+            return columnIndex > 0 // Column name is read-only
+        }
+
+        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+            val col = columns[rowIndex]
+            return when (columnIndex) {
+                0 -> col
+                1 -> wipLimits[col]?.toString() ?: ""
+                2 -> columnAgents[col] ?: MoeBundle.message("moe.settings.none")
+                else -> ""
+            }
+        }
+
+        override fun setValueAt(aValue: Any?, rowIndex: Int, columnIndex: Int) {
+            val col = columns[rowIndex]
+            when (columnIndex) {
+                1 -> {
+                    val text = (aValue as? String)?.trim() ?: ""
+                    val num = text.toIntOrNull()
+                    wipLimits[col] = if (num != null && num > 0) num else null
+                }
+                2 -> {
+                    val value = aValue as? String
+                    columnAgents[col] = if (value == MoeBundle.message("moe.settings.none") || value.isNullOrBlank()) null else value
+                }
+            }
+            fireTableCellUpdated(rowIndex, columnIndex)
+        }
+    }
+}

--- a/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/MoeToolWindowPanel.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/MoeToolWindowPanel.kt
@@ -162,6 +162,16 @@ class MoeToolWindowPanel(private val project: Project) : JBPanel<MoeToolWindowPa
                         }
                     }
                     popup.add(teamCheckbox)
+                    val agentTeamCheckbox = object : JCheckBoxMenuItem(
+                        MoeBundle.message("moe.panel.agentsMenu.agentTeams"),
+                        TerminalAgentLauncher.isAgentTeamModeEnabled(project)
+                    ) {
+                        override fun doClick(pressTime: Int) {
+                            isSelected = !isSelected
+                            TerminalAgentLauncher.setAgentTeamModeEnabled(project, isSelected)
+                        }
+                    }
+                    popup.add(agentTeamCheckbox)
                     popup.add(JSeparator())
 
                     fun launchWithProvider(role: String?, provider: TerminalAgentLauncher.AgentProvider) {
@@ -185,6 +195,8 @@ class MoeToolWindowPanel(private val project: Project) : JBPanel<MoeToolWindowPa
                         }
                         if (role != null) {
                             TerminalAgentLauncher.startAgent(project, role, command)
+                        } else if (TerminalAgentLauncher.isAgentTeamModeEnabled(project) && provider == TerminalAgentLauncher.AgentProvider.CLAUDE) {
+                            TerminalAgentLauncher.launchAgentTeam(project, command)
                         } else {
                             TerminalAgentLauncher.startAgents(project, command)
                         }
@@ -258,12 +270,14 @@ class MoeToolWindowPanel(private val project: Project) : JBPanel<MoeToolWindowPa
         val proposalPanel = ProposalPanel(project)
         val activityLogPanel = ActivityLogPanel(project)
         val chatPanel = ChatPanel(project)
+        val boardSettingsPanel = BoardSettingsPanel(project)
 
         val tabbedPane = JTabbedPane().apply {
             addTab(MoeBundle.message("moe.tab.board"), scroll)
             addTab(MoeBundle.message("moe.tab.proposals"), proposalPanel)
             addTab(MoeBundle.message("moe.tab.activityLog"), activityLogPanel)
             addTab(MoeBundle.message("moe.tab.chat"), chatPanel)
+            addTab(MoeBundle.message("moe.tab.boardSettings"), boardSettingsPanel)
         }
         add(tabbedPane, BorderLayout.CENTER)
 
@@ -271,6 +285,7 @@ class MoeToolWindowPanel(private val project: Project) : JBPanel<MoeToolWindowPa
         Disposer.register(this, proposalPanel)
         Disposer.register(this, activityLogPanel)
         Disposer.register(this, chatPanel)
+        Disposer.register(this, boardSettingsPanel)
 
         stateListener = object : MoeStateListener {
             override fun onState(state: MoeState) {
@@ -445,13 +460,18 @@ class MoeToolWindowPanel(private val project: Project) : JBPanel<MoeToolWindowPa
             }
 
             val workflowOrder = listOf("BACKLOG", "PLANNING", "AWAITING_APPROVAL", "WORKING", "REVIEW", "DONE")
+            // Display-aware column order: AWAITING_APPROVAL is shown in PLANNING column,
+            // so navigation should treat it as if it's in the PLANNING position.
+            val displayColumnOrder = listOf("BACKLOG", "PLANNING", "WORKING", "REVIEW", "DONE")
             fun getNextStatus(current: String): String? {
-                val idx = workflowOrder.indexOf(current)
-                return if (idx >= 0 && idx < workflowOrder.size - 1) workflowOrder[idx + 1] else null
+                val displayPos = if (current == "AWAITING_APPROVAL") "PLANNING" else current
+                val idx = displayColumnOrder.indexOf(displayPos)
+                return if (idx >= 0 && idx < displayColumnOrder.size - 1) displayColumnOrder[idx + 1] else null
             }
             fun getPreviousStatus(current: String): String? {
-                val idx = workflowOrder.indexOf(current)
-                return if (idx > 0) workflowOrder[idx - 1] else null
+                val displayPos = if (current == "AWAITING_APPROVAL") "PLANNING" else current
+                val idx = displayColumnOrder.indexOf(displayPos)
+                return if (idx > 0) displayColumnOrder[idx - 1] else null
             }
 
             fun handleNext(task: Task) {

--- a/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/WorkerPanel.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/WorkerPanel.kt
@@ -42,6 +42,12 @@ class WorkerPanel : JBPanel<WorkerPanel>(WrapLayout(FlowLayout.LEFT, 8, 4)) {
             }
 
             // Render team sections
+            if (teamWorkers.isNotEmpty()) {
+                add(JBLabel(MoeBundle.message("moe.worker.teamSection")).apply {
+                    foreground = BoardStyles.textPrimary
+                    font = font.deriveFont(Font.BOLD, font.size - 1f)
+                })
+            }
             for ((teamId, members) in teamWorkers) {
                 val team = teamMap[teamId] ?: continue
                 add(JBLabel("[${team.name}]").apply {
@@ -55,7 +61,7 @@ class WorkerPanel : JBPanel<WorkerPanel>(WrapLayout(FlowLayout.LEFT, 8, 4)) {
 
             // Render solo workers
             if (soloWorkers.isNotEmpty() && teamWorkers.isNotEmpty()) {
-                add(JBLabel("[Solo]").apply {
+                add(JBLabel(MoeBundle.message("moe.worker.soloSection")).apply {
                     foreground = JBColor.GRAY
                     font = font.deriveFont(Font.BOLD, font.size - 1f)
                 })

--- a/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/board/TaskCard.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/board/TaskCard.kt
@@ -86,6 +86,10 @@ class TaskCard(
             meta.add(chip(humanizeStatus(task.status), subtle = true))
         }
 
+        if (task.assignedWorkerId?.startsWith("team-") == true) {
+            meta.add(chip(MoeBundle.message("moe.worker.teamIndicator"), subtle = true))
+        }
+
         // Step progress chip (e.g. "3/7 steps")
         if (task.implementationPlan.isNotEmpty()) {
             val completed = task.implementationPlan.count { it.status == "COMPLETED" }

--- a/moe-jetbrains/src/main/kotlin/com/moe/util/MoeProjectInitializer.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/util/MoeProjectInitializer.kt
@@ -73,6 +73,19 @@ object MoeProjectInitializer {
             activity.writeText("")
         }
 
+        // Create CLAUDE.md with agent instructions if not present
+        val claudeMd = File(moeDir, "CLAUDE.md")
+        if (!claudeMd.exists()) {
+            claudeMd.writeText(buildString {
+                appendLine("# Moe Project Instructions")
+                appendLine()
+                appendLine("# Agent Teams")
+                appendLine("# When using Claude Agent Teams mode, teammates coordinate through Moe MCP tools.")
+                appendLine("# See docs/MCP_SERVER.md for tool documentation.")
+                appendLine()
+            })
+        }
+
         MoeProjectRegistry.registerProject(root.absolutePath, projectName ?: root.name)
     }
 

--- a/moe-jetbrains/src/main/kotlin/com/moe/util/TerminalAgentLauncher.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/util/TerminalAgentLauncher.kt
@@ -88,6 +88,7 @@ object TerminalAgentLauncher {
     private const val LAST_PROVIDER_KEY = "moe.lastUsedProvider"
     private const val CUSTOM_COMMAND_KEY = "moe.customAgentCommand"
     private const val TEAM_MODE_KEY = "moe.teamModeEnabled"
+    private const val AGENT_TEAM_MODE_KEY = "moe.agentTeamMode"
 
     fun getLastUsedProvider(project: Project): AgentProvider {
         val stored = PropertiesComponent.getInstance(project).getValue(LAST_PROVIDER_KEY, AgentProvider.CLAUDE.name)
@@ -115,6 +116,13 @@ object TerminalAgentLauncher {
 
     fun setTeamModeEnabled(project: Project, enabled: Boolean) {
         PropertiesComponent.getInstance(project).setValue(TEAM_MODE_KEY, enabled)
+    }
+
+    fun isAgentTeamModeEnabled(project: Project): Boolean =
+        PropertiesComponent.getInstance(project).getBoolean(AGENT_TEAM_MODE_KEY, false)
+
+    fun setAgentTeamModeEnabled(project: Project, enabled: Boolean) {
+        PropertiesComponent.getInstance(project).setValue(AGENT_TEAM_MODE_KEY, enabled)
     }
 
     fun resolveAgentCommand(project: Project, provider: AgentProvider): String {
@@ -224,6 +232,55 @@ object TerminalAgentLauncher {
     fun startAgent(project: Project, role: String, agentCommand: String? = null) {
         val ctx = resolveContext(project, agentCommand) ?: return
         launchRole(project, ctx, role)
+    }
+
+    fun launchAgentTeam(project: Project, agentCommand: String? = null) {
+        val ctx = resolveContext(project, agentCommand) ?: return
+        val tabName = MoeBundle.message("moe.panel.agentsMenu.leadTab")
+        val workerId = "lead-${UUID.randomUUID().toString().substring(0, 4)}"
+        val command = when (ctx.script.kind) {
+            ScriptKind.BASH -> {
+                val envPrefix = if (ctx.envOverrides.isNotEmpty()) {
+                    ctx.envOverrides.entries.joinToString(" ") { (key, value) ->
+                        "$key=${shQuote(value)}"
+                    } + " "
+                } else {
+                    ""
+                }
+                "${envPrefix}CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 bash ${shQuote(ctx.script.file.absolutePath)} --lead --project ${shQuote(ctx.basePath)} --worker-id ${shQuote(workerId)} --command ${shQuote(ctx.agentCommand)}"
+            }
+            ScriptKind.POWERSHELL -> {
+                val envSet = if (ctx.envOverrides.isNotEmpty()) {
+                    ctx.envOverrides.entries.joinToString("; ") { (key, value) ->
+                        "\$env:$key=${psQuote(value)}"
+                    } + "; "
+                } else {
+                    ""
+                }
+                val psCommand = "${envSet}\$env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS='1'; & ${psQuote(ctx.script.file.absolutePath)} -Lead -Project ${psQuote(ctx.basePath)} -WorkerId ${psQuote(workerId)} -Command ${psQuote(ctx.agentCommand)}"
+                val escaped = psCommand.replace("\"", "`\"").replace("\$", "`\$")
+                "powershell -NoProfile -ExecutionPolicy Bypass -Command \"$escaped\""
+            }
+        }
+        try {
+            val widget = createTerminalWidget(ctx.manager, ctx.basePath, tabName)
+            if (widget != null) {
+                sendCommand(widget, command)
+            } else {
+                LOG.warn("Failed to create terminal widget for tab \"$tabName\"")
+                Messages.showWarningDialog(
+                    project,
+                    "Failed to create terminal for \"$tabName\". Ensure the Terminal plugin is enabled.",
+                    "Moe"
+                )
+            }
+        } catch (ex: Exception) {
+            Messages.showErrorDialog(
+                project,
+                "Failed to start terminal \"$tabName\": ${ex.message}",
+                "Moe"
+            )
+        }
     }
 
     private fun buildCommand(

--- a/moe-jetbrains/src/main/resources/messages/MoeBundle.properties
+++ b/moe-jetbrains/src/main/resources/messages/MoeBundle.properties
@@ -15,6 +15,8 @@ moe.panel.agentsMenu.qa=QA
 moe.panel.agentsMenu.customPrompt=Enter the agent command:
 moe.panel.agentsMenu.customTitle=Custom Agent Command
 moe.panel.agentsMenu.teamMode=Team Mode (parallel agents)
+moe.panel.agentsMenu.agentTeams=Claude Agent Teams (experimental)
+moe.panel.agentsMenu.leadTab=Moe Lead
 moe.panel.provider.claude=Claude
 moe.panel.provider.codex=Codex
 moe.panel.provider.gemini=Gemini
@@ -29,6 +31,7 @@ moe.panel.currentProject=Current: {0}
 moe.tab.board=Board
 moe.tab.proposals=Proposals
 moe.tab.activityLog=Activity Log
+moe.tab.boardSettings=Board Settings
 
 # Column Titles
 moe.column.backlog=Backlog
@@ -124,6 +127,15 @@ moe.settings.agentCommandLabel=Agent Command
 moe.settings.agentCommandHint=<html><small>CLI command to launch agents (claude, codex, gemini, or custom path)</small></html>
 moe.settings.branchPatternHint=<html><small>Variables: {epicId}, {taskId}</small></html>
 moe.settings.commitPatternHint=<html><small>Variables: {epicId}, {taskTitle}</small></html>
+
+# Board Settings
+moe.settings.columnName=Column
+moe.settings.wipLimit=WIP Limit
+moe.settings.assignedAgent=Agent
+moe.settings.save=Save
+moe.settings.saved=Settings saved
+moe.settings.none=(none)
+
 moe.settings.enableAgentTeams=Enable Agent Teams (Claude Code workers only)
 moe.settings.enableAgentTeamsHint=<html><small>When enabled, Claude Code workers can spawn teammate instances for parallel sub-step work.</small></html>
 
@@ -161,6 +173,11 @@ moe.label.comments=Comments
 moe.message.noComments=No comments yet.
 moe.message.typeQuestion=Type a question for the agent...
 moe.button.askQuestion=Ask
+
+# Workers
+moe.worker.teamIndicator=[Team]
+moe.worker.teamSection=Team Agents
+moe.worker.soloSection=Individual Agents
 
 # Chat
 moe.tab.chat=Chat

--- a/packages/moe-daemon/src/state/StateManager.ts
+++ b/packages/moe-daemon/src/state/StateManager.ts
@@ -1572,10 +1572,26 @@ export class StateManager {
       columnLimits = merged;
     }
 
+    // Sanitize columnAgents: merge with existing, validate values are valid role strings
+    let columnAgents = this.project.settings.columnAgents;
+    if (settings.columnAgents !== undefined) {
+      const incoming = settings.columnAgents || {};
+      const merged: Record<string, string> = { ...(columnAgents || {}) };
+      const validRoles = ['architect', 'worker', 'qa'];
+      for (const [key, value] of Object.entries(incoming)) {
+        if (typeof value !== 'string' || !validRoles.includes(value)) {
+          throw new Error(`Invalid column agent for ${key}: must be one of ${validRoles.join(', ')}`);
+        }
+        merged[key] = value;
+      }
+      columnAgents = merged;
+    }
+
     const updatedSettings: ProjectSettings = {
       ...this.project.settings,
       ...settings,
-      columnLimits
+      columnLimits,
+      columnAgents
     };
 
     const updatedProject: Project = {
@@ -2366,6 +2382,8 @@ export class StateManager {
         agentCommand: sanitizeString(project.settings?.agentCommand, 'agentCommand', 256, 'claude'),
         enableAgentTeams: sanitizeBoolean(project.settings?.enableAgentTeams, false),
         columnLimits: project.settings?.columnLimits as Record<string, number> | undefined,
+        columnAgents: project.settings?.columnAgents as Record<string, string> | undefined,
+        agentTeamMode: sanitizeBoolean(project.settings?.agentTeamMode, false),
         chatEnabled: sanitizeBoolean(project.settings?.chatEnabled, true),
         chatMaxAgentHops: sanitizeNumber(project.settings?.chatMaxAgentHops, 4, 1, 20),
       },

--- a/packages/moe-daemon/src/tools/__tests__/waitForApproval.test.ts
+++ b/packages/moe-daemon/src/tools/__tests__/waitForApproval.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { StateManager } from '../../state/StateManager.js';
+import { waitForApprovalTool } from '../waitForApproval.js';
+import type { Task, Epic, Project } from '../../types/schema.js';
+
+describe('moe.wait_for_approval', () => {
+  let testDir: string;
+  let moePath: string;
+  let state: StateManager;
+
+  function setupMoeFolder(projectOverrides: Partial<Project> = {}) {
+    fs.mkdirSync(moePath, { recursive: true });
+    fs.mkdirSync(path.join(moePath, 'epics'));
+    fs.mkdirSync(path.join(moePath, 'tasks'));
+    fs.mkdirSync(path.join(moePath, 'workers'));
+    fs.mkdirSync(path.join(moePath, 'proposals'));
+
+    const project = {
+      id: 'proj-test',
+      name: 'Test Project',
+      rootPath: testDir,
+      globalRails: {
+        techStack: ['typescript'],
+        forbiddenPatterns: [],
+        requiredPatterns: [],
+        formatting: '',
+        testing: '',
+        customRules: [],
+      },
+      settings: {
+        approvalMode: 'CONTROL',
+        speedModeDelayMs: 2000,
+        autoCreateBranch: true,
+        branchPattern: 'moe/{epicId}/{taskId}',
+        commitPattern: 'feat({epicId}): {taskTitle}',
+        agentCommand: 'claude',
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...projectOverrides,
+    };
+
+    fs.writeFileSync(path.join(moePath, 'project.json'), JSON.stringify(project, null, 2));
+    return project;
+  }
+
+  function createEpic(overrides: Partial<Epic> = {}): Epic {
+    const epic: Epic = {
+      id: 'epic-1',
+      projectId: 'proj-test',
+      title: 'Test Epic',
+      description: 'Epic description',
+      architectureNotes: 'Some notes',
+      epicRails: [],
+      status: 'ACTIVE',
+      order: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    };
+    fs.writeFileSync(path.join(moePath, 'epics', `${epic.id}.json`), JSON.stringify(epic, null, 2));
+    return epic;
+  }
+
+  function createTask(overrides: Partial<Task> = {}): Task {
+    const task: Task = {
+      id: 'task-1',
+      epicId: 'epic-1',
+      title: 'Test Task',
+      description: 'Task description',
+      definitionOfDone: ['Tests pass'],
+      taskRails: [],
+      implementationPlan: [],
+      status: 'BACKLOG',
+      assignedWorkerId: null,
+      branch: null,
+      prLink: null,
+      reopenCount: 0,
+      reopenReason: null,
+      createdBy: 'HUMAN',
+      parentTaskId: null,
+      priority: 'MEDIUM',
+      order: 1,
+      comments: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    };
+    fs.writeFileSync(path.join(moePath, 'tasks', `${task.id}.json`), JSON.stringify(task, null, 2));
+    return task;
+  }
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-wait-approval-test-'));
+    moePath = path.join(testDir, '.moe');
+    state = new StateManager({ projectPath: testDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns approved=true immediately when task is already WORKING', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'WORKING' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const result = await tool.handler({ taskId: 'task-1' }, state) as { approved: boolean; taskId: string };
+
+    expect(result.approved).toBe(true);
+    expect(result.taskId).toBe('task-1');
+  });
+
+  it('returns rejected=true immediately when task is PLANNING with reopenReason', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'PLANNING', reopenReason: 'Needs more detail' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const result = await tool.handler({ taskId: 'task-1' }, state) as { rejected: boolean; reason: string; taskId: string };
+
+    expect(result.rejected).toBe(true);
+    expect(result.reason).toBe('Needs more detail');
+    expect(result.taskId).toBe('task-1');
+  });
+
+  it('returns status info when task is not in AWAITING_APPROVAL', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'BACKLOG' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const result = await tool.handler({ taskId: 'task-1' }, state) as {
+      approved: boolean;
+      rejected: boolean;
+      timedOut: boolean;
+      status: string;
+      taskId: string;
+    };
+
+    expect(result.approved).toBe(false);
+    expect(result.rejected).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.status).toBe('BACKLOG');
+  });
+
+  it('throws for non-existent task', async () => {
+    setupMoeFolder();
+    createEpic();
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    await expect(tool.handler({ taskId: 'nonexistent' }, state)).rejects.toThrow('Task not found');
+  });
+
+  it('throws for missing taskId', async () => {
+    setupMoeFolder();
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    await expect(tool.handler({}, state)).rejects.toThrow('Missing required field: taskId');
+  });
+
+  it('resolves with approved=true when task moves to WORKING', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'AWAITING_APPROVAL' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const promise = tool.handler({ taskId: 'task-1', timeoutMs: 5000 }, state) as Promise<{
+      approved: boolean;
+      taskId: string;
+    }>;
+
+    // Simulate approval after a short delay
+    setTimeout(async () => {
+      await state.approveTask('task-1');
+    }, 50);
+
+    const result = await promise;
+    expect(result.approved).toBe(true);
+    expect(result.taskId).toBe('task-1');
+  });
+
+  it('resolves with rejected=true when task moves back to PLANNING', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'AWAITING_APPROVAL' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const promise = tool.handler({ taskId: 'task-1', timeoutMs: 5000 }, state) as Promise<{
+      rejected: boolean;
+      reason: string;
+      taskId: string;
+    }>;
+
+    // Simulate rejection after a short delay
+    setTimeout(async () => {
+      await state.rejectTask('task-1', 'Plan is incomplete');
+    }, 50);
+
+    const result = await promise;
+    expect(result.rejected).toBe(true);
+    expect(result.reason).toBe('Plan is incomplete');
+    expect(result.taskId).toBe('task-1');
+  });
+
+  it('resolves with timedOut=true when timeout expires', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'AWAITING_APPROVAL' });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    // Use minimum timeout (1000ms) for fast test
+    const result = await tool.handler({ taskId: 'task-1', timeoutMs: 1000 }, state) as {
+      timedOut: boolean;
+      taskId: string;
+    };
+
+    expect(result.timedOut).toBe(true);
+    expect(result.taskId).toBe('task-1');
+  }, 10000);
+
+  it('ignores updates to other tasks', async () => {
+    setupMoeFolder();
+    createEpic();
+    createTask({ id: 'task-1', status: 'AWAITING_APPROVAL' });
+    createTask({ id: 'task-2', status: 'AWAITING_APPROVAL', order: 2 });
+    await state.load();
+
+    const tool = waitForApprovalTool(state);
+    const promise = tool.handler({ taskId: 'task-1', timeoutMs: 2000 }, state) as Promise<{
+      approved?: boolean;
+      timedOut?: boolean;
+    }>;
+
+    // Approve task-2, not task-1 - should not resolve the waiter
+    setTimeout(async () => {
+      await state.approveTask('task-2');
+    }, 50);
+
+    // Then approve task-1 shortly after
+    setTimeout(async () => {
+      await state.approveTask('task-1');
+    }, 100);
+
+    const result = await promise;
+    expect(result.approved).toBe(true);
+  }, 10000);
+});
+
+describe('agentTeamMode settings normalization', () => {
+  let testDir: string;
+  let moePath: string;
+
+  function setupMoeFolder(settingsOverrides: Record<string, unknown> = {}) {
+    fs.mkdirSync(moePath, { recursive: true });
+    fs.mkdirSync(path.join(moePath, 'epics'));
+    fs.mkdirSync(path.join(moePath, 'tasks'));
+    fs.mkdirSync(path.join(moePath, 'workers'));
+    fs.mkdirSync(path.join(moePath, 'proposals'));
+
+    const project = {
+      id: 'proj-test',
+      name: 'Test Project',
+      rootPath: testDir,
+      globalRails: {
+        techStack: [],
+        forbiddenPatterns: [],
+        requiredPatterns: [],
+        formatting: '',
+        testing: '',
+        customRules: [],
+      },
+      settings: {
+        approvalMode: 'CONTROL',
+        speedModeDelayMs: 2000,
+        autoCreateBranch: true,
+        branchPattern: 'moe/{epicId}/{taskId}',
+        commitPattern: 'feat({epicId}): {taskTitle}',
+        agentCommand: 'claude',
+        ...settingsOverrides,
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    fs.writeFileSync(path.join(moePath, 'project.json'), JSON.stringify(project, null, 2));
+  }
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-settings-test-'));
+    moePath = path.join(testDir, '.moe');
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('defaults agentTeamMode to false when not set', async () => {
+    setupMoeFolder();
+    const state = new StateManager({ projectPath: testDir });
+    await state.load();
+
+    expect(state.project?.settings.agentTeamMode).toBe(false);
+  });
+
+  it('preserves agentTeamMode=true when explicitly set', async () => {
+    setupMoeFolder({ agentTeamMode: true });
+    const state = new StateManager({ projectPath: testDir });
+    await state.load();
+
+    expect(state.project?.settings.agentTeamMode).toBe(true);
+  });
+
+  it('normalizes non-boolean agentTeamMode to false', async () => {
+    setupMoeFolder({ agentTeamMode: 'yes' });
+    const state = new StateManager({ projectPath: testDir });
+    await state.load();
+
+    expect(state.project?.settings.agentTeamMode).toBe(false);
+  });
+
+  it('updates agentTeamMode via updateSettings', async () => {
+    setupMoeFolder();
+    const state = new StateManager({ projectPath: testDir });
+    await state.load();
+
+    expect(state.project?.settings.agentTeamMode).toBe(false);
+
+    await state.updateSettings({ agentTeamMode: true });
+    expect(state.project?.settings.agentTeamMode).toBe(true);
+
+    await state.updateSettings({ agentTeamMode: false });
+    expect(state.project?.settings.agentTeamMode).toBe(false);
+  });
+});

--- a/packages/moe-daemon/src/tools/index.ts
+++ b/packages/moe-daemon/src/tools/index.ts
@@ -44,6 +44,7 @@ import { chatPinTool } from './chatPin.js';
 import { chatUnpinTool } from './chatUnpin.js';
 import { chatDecisionTool } from './chatDecision.js';
 import { chatCreateChannelTool } from './chatCreateChannel.js';
+import { waitForApprovalTool } from './waitForApproval.js';
 
 export type ToolHandler = (args: unknown, state: StateManager) => Promise<unknown>;
 
@@ -96,6 +97,7 @@ export function getTools(state: StateManager): ToolDefinition[] {
     chatPinTool(state),
     chatUnpinTool(state),
     chatDecisionTool(state),
-    chatCreateChannelTool(state)
+    chatCreateChannelTool(state),
+    waitForApprovalTool(state)
   ];
 }

--- a/packages/moe-daemon/src/tools/waitForApproval.ts
+++ b/packages/moe-daemon/src/tools/waitForApproval.ts
@@ -1,0 +1,96 @@
+import type { ToolDefinition } from './index.js';
+import type { StateManager } from '../state/StateManager.js';
+import { notFound, missingRequired } from '../util/errors.js';
+import { logger } from '../util/logger.js';
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+export function waitForApprovalTool(_state: StateManager): ToolDefinition {
+  return {
+    name: 'moe.wait_for_approval',
+    description: 'Block until a task in AWAITING_APPROVAL is approved or rejected. Returns immediately if the task is already WORKING (approved) or PLANNING with reopenReason (rejected).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string', description: 'The task ID to wait for approval on' },
+        timeoutMs: { type: 'number', description: 'Max wait time in ms (default 300000, max 600000)' }
+      },
+      required: ['taskId'],
+      additionalProperties: false
+    },
+    handler: async (args, state) => {
+      const params = (args || {}) as { taskId?: string; timeoutMs?: number };
+      const taskId = params.taskId;
+      if (!taskId) {
+        throw missingRequired('taskId');
+      }
+
+      const task = state.getTask(taskId);
+      if (!task) throw notFound('Task', taskId);
+
+      // Already approved - return immediately
+      if (task.status === 'WORKING') {
+        return { approved: true, taskId };
+      }
+
+      // Already rejected (back to PLANNING with a reason) - return immediately
+      if (task.status === 'PLANNING' && task.reopenReason !== null) {
+        return { rejected: true, reason: task.reopenReason, taskId };
+      }
+
+      // If not in AWAITING_APPROVAL, return current status
+      if (task.status !== 'AWAITING_APPROVAL') {
+        return { approved: false, rejected: false, timedOut: false, status: task.status, taskId };
+      }
+
+      const timeoutMs = Math.min(
+        Math.max(params.timeoutMs || DEFAULT_TIMEOUT_MS, 1000),
+        MAX_TIMEOUT_MS
+      );
+
+      logger.info({ taskId, timeoutMs }, 'Waiting for task approval');
+
+      return new Promise<unknown>((resolve) => {
+        const cleanup = () => {
+          clearTimeout(timer);
+          unsubscribe();
+        };
+
+        const timer = setTimeout(() => {
+          cleanup();
+          logger.info({ taskId }, 'Wait for approval timed out');
+          resolve({ timedOut: true, taskId });
+        }, timeoutMs);
+
+        // Don't prevent process exit
+        if (timer.unref) {
+          timer.unref();
+        }
+
+        const unsubscribe = state.subscribe((event) => {
+          if (event.type !== 'TASK_UPDATED') return;
+          if (event.payload.id !== taskId) return;
+
+          const updatedTask = event.payload;
+
+          // Approved - task moved to WORKING
+          if (updatedTask.status === 'WORKING') {
+            cleanup();
+            logger.info({ taskId }, 'Task approved');
+            resolve({ approved: true, taskId });
+            return;
+          }
+
+          // Rejected - task moved back to PLANNING
+          if (updatedTask.status === 'PLANNING') {
+            cleanup();
+            logger.info({ taskId, reason: updatedTask.reopenReason }, 'Task rejected');
+            resolve({ rejected: true, reason: updatedTask.reopenReason, taskId });
+            return;
+          }
+        });
+      });
+    }
+  };
+}

--- a/packages/moe-daemon/src/types/schema.ts
+++ b/packages/moe-daemon/src/types/schema.ts
@@ -45,6 +45,8 @@ export interface ProjectSettings {
   agentCommand: string;
   enableAgentTeams: boolean;
   columnLimits?: Record<string, number>;
+  columnAgents?: Record<string, string>;
+  agentTeamMode?: boolean;
   chatEnabled?: boolean;              // default: true
   chatMaxAgentHops?: number;          // default: 4 (loop guard threshold)
 }

--- a/scripts/deploy-plugin.sh
+++ b/scripts/deploy-plugin.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Build, install, and restart IntelliJ IDEA with the Moe plugin.
+# Usage: ./scripts/deploy-plugin.sh [--no-restart]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_DIR="$PROJECT_ROOT/moe-jetbrains"
+DIST_ZIP="$(ls -t "$PLUGIN_DIR/build/distributions/moe-jetbrains-"*.zip 2>/dev/null | head -1)"
+NO_RESTART=false
+
+for arg in "$@"; do
+    case $arg in
+        --no-restart) NO_RESTART=true ;;
+        --help|-h)
+            echo "Usage: $0 [--no-restart]"
+            echo "  --no-restart   Build and install but don't restart the IDE"
+            exit 0
+            ;;
+    esac
+done
+
+# Find the latest IntelliJ IDEA plugins directory
+IDEA_PLUGINS=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    JB_ROOT="$HOME/Library/Application Support/JetBrains"
+else
+    JB_ROOT="$HOME/.config/JetBrains"
+fi
+
+for dir in "$JB_ROOT/IntelliJIdea"*/plugins; do
+    [ -d "$dir" ] && IDEA_PLUGINS="$dir"
+done
+
+if [ -z "$IDEA_PLUGINS" ]; then
+    echo "[ERROR] Could not find IntelliJ IDEA plugins directory under $JB_ROOT"
+    exit 1
+fi
+
+echo "[1/3] Building plugin..."
+(cd "$PLUGIN_DIR" && ./gradlew buildPlugin -q)
+
+if [ ! -f "$DIST_ZIP" ]; then
+    echo "[ERROR] Build artifact not found: $DIST_ZIP"
+    exit 1
+fi
+
+echo "[2/3] Installing to $IDEA_PLUGINS ..."
+rm -rf "$IDEA_PLUGINS/moe-jetbrains"
+unzip -qo "$DIST_ZIP" -d "$IDEA_PLUGINS/"
+echo "[OK] Plugin installed."
+
+if [ "$NO_RESTART" = true ]; then
+    echo "Skipping IDE restart (--no-restart)."
+    exit 0
+fi
+
+echo "[3/3] Restarting IntelliJ IDEA..."
+pkill -f "IntelliJ IDEA" 2>/dev/null || true
+sleep 2
+open -a "IntelliJ IDEA"
+echo "[OK] Done."

--- a/scripts/deploy-plugin.sh
+++ b/scripts/deploy-plugin.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_DIR="$PROJECT_ROOT/moe-jetbrains"
-DIST_ZIP="$(ls -t "$PLUGIN_DIR/build/distributions/moe-jetbrains-"*.zip 2>/dev/null | head -1)"
 NO_RESTART=false
 
 for arg in "$@"; do
@@ -29,6 +28,7 @@ else
     JB_ROOT="$HOME/.config/JetBrains"
 fi
 
+# Pick the newest IntelliJIdea version directory
 for dir in "$JB_ROOT/IntelliJIdea"*/plugins; do
     [ -d "$dir" ] && IDEA_PLUGINS="$dir"
 done
@@ -41,12 +41,14 @@ fi
 echo "[1/3] Building plugin..."
 (cd "$PLUGIN_DIR" && ./gradlew buildPlugin -q)
 
-if [ ! -f "$DIST_ZIP" ]; then
-    echo "[ERROR] Build artifact not found: $DIST_ZIP"
+# Find the zip AFTER the build completes
+DIST_ZIP="$(ls -t "$PLUGIN_DIR/build/distributions/moe-jetbrains-"*.zip 2>/dev/null | head -1)"
+if [ -z "$DIST_ZIP" ] || [ ! -f "$DIST_ZIP" ]; then
+    echo "[ERROR] Build artifact not found in $PLUGIN_DIR/build/distributions/"
     exit 1
 fi
 
-echo "[2/3] Installing to $IDEA_PLUGINS ..."
+echo "[2/3] Installing $DIST_ZIP to $IDEA_PLUGINS ..."
 rm -rf "$IDEA_PLUGINS/moe-jetbrains"
 unzip -qo "$DIST_ZIP" -d "$IDEA_PLUGINS/"
 echo "[OK] Plugin installed."
@@ -57,7 +59,27 @@ if [ "$NO_RESTART" = true ]; then
 fi
 
 echo "[3/3] Restarting IntelliJ IDEA..."
-pkill -f "IntelliJ IDEA" 2>/dev/null || true
-sleep 2
-open -a "IntelliJ IDEA"
+# Kill IntelliJ IDEA gracefully via osascript on macOS, fall back to pkill
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    osascript -e 'tell application "IntelliJ IDEA" to quit' 2>/dev/null || true
+    # Wait for it to actually exit
+    for i in {1..10}; do
+        pgrep -f "IntelliJ IDEA" >/dev/null 2>&1 || break
+        sleep 1
+    done
+    # Force kill if still running
+    pkill -f "IntelliJ IDEA" 2>/dev/null || true
+    sleep 2
+    open -a "IntelliJ IDEA"
+else
+    pkill -f "idea" 2>/dev/null || true
+    sleep 2
+    # On Linux try common locations
+    idea_bin="$(command -v idea 2>/dev/null || echo "")"
+    if [ -n "$idea_bin" ]; then
+        nohup "$idea_bin" >/dev/null 2>&1 &
+    else
+        echo "[WARN] Could not find 'idea' command. Please restart the IDE manually."
+    fi
+fi
 echo "[OK] Done."

--- a/scripts/moe-agent.sh
+++ b/scripts/moe-agent.sh
@@ -133,6 +133,7 @@ NO_LOOP=false
 TEAM=""
 CODEX_EXEC=false
 GEMINI_EXEC=false
+LEAD_MODE=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -181,6 +182,10 @@ while [[ $# -gt 0 ]]; do
             TEAM="$2"
             shift 2
             ;;
+        --lead)
+            LEAD_MODE=true
+            shift
+            ;;
         --codex-exec)
             CODEX_EXEC=true
             shift
@@ -206,6 +211,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --poll-interval SECS     Seconds between task polls (default: 30)"
             echo "  --no-loop                Run once and exit (no polling)"
             echo "  -t, --team NAME          Team name for parallel same-role agents"
+            echo "  --lead                   Launch as lead agent using Claude Agent Teams"
             echo "  --codex-exec             Use codex exec mode (non-interactive, headless)"
             echo "  --gemini-exec            Use gemini headless mode (non-interactive, --yolo)"
             echo "  --help, -h               Show this help"
@@ -213,6 +219,7 @@ while [[ $# -gt 0 ]]; do
             echo "Examples:"
             echo "  $0 --role architect --project ~/myproject"
             echo "  $0 -r worker -n myproject"
+            echo "  $0 --lead --project ~/myproject"
             echo "  $0 --list-projects"
             exit 0
             ;;
@@ -224,8 +231,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Validate role
-if [[ ! "$ROLE" =~ ^(architect|worker|qa)$ ]]; then
+# Validate role (skip when in lead mode)
+if [ "$LEAD_MODE" = false ] && [[ ! "$ROLE" =~ ^(architect|worker|qa)$ ]]; then
     echo -e "${RED}Invalid role: $ROLE${NC}"
     echo "Valid roles: architect, worker, qa"
     exit 1
@@ -396,7 +403,11 @@ fi
 export MOE_PROJECT_PATH="$PROJECT"
 if [ -z "$WORKER_ID" ]; then
     SHORT_ID=$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
-    WORKER_ID="${ROLE}-${SHORT_ID}"
+    if [ "$LEAD_MODE" = true ]; then
+        WORKER_ID="lead-${SHORT_ID}"
+    else
+        WORKER_ID="${ROLE}-${SHORT_ID}"
+    fi
 fi
 export MOE_WORKER_ID="$WORKER_ID"
 
@@ -883,25 +894,34 @@ except:
     fi
 fi
 
-# Determine status filter based on role
-case $ROLE in
-    architect)
-        STATUSES='["PLANNING"]'
-        ;;
-    worker)
-        STATUSES='["WORKING"]'
-        ;;
-    qa)
-        STATUSES='["REVIEW"]'
-        ;;
-esac
+# Determine status filter based on role (not needed for lead mode)
+STATUSES='[]'
+if [ "$LEAD_MODE" = false ]; then
+    case $ROLE in
+        architect)
+            STATUSES='["PLANNING"]'
+            ;;
+        worker)
+            STATUSES='["WORKING"]'
+            ;;
+        qa)
+            STATUSES='["REVIEW"]'
+            ;;
+    esac
+fi
 
 echo ""
 echo -e "${BLUE}================================${NC}"
-echo -e "Role:      ${GREEN}$ROLE${NC}"
+if [ "$LEAD_MODE" = true ]; then
+    echo -e "Mode:      ${GREEN}LEAD (Agent Teams)${NC}"
+else
+    echo -e "Role:      ${GREEN}$ROLE${NC}"
+fi
 echo -e "Project:   $PROJECT"
 echo -e "WorkerId:  $WORKER_ID"
-echo -e "AutoClaim: $AUTO_CLAIM"
+if [ "$LEAD_MODE" = false ]; then
+    echo -e "AutoClaim: $AUTO_CLAIM"
+fi
 if [ -n "$TEAM" ]; then
     echo -e "Team:      ${GREEN}$TEAM${NC}"
 fi
@@ -963,6 +983,142 @@ if [ -f "$KNOWN_ISSUES_PATH" ]; then
     KNOWN_ISSUES=$(cat "$KNOWN_ISSUES_PATH")
     echo -e "${GREEN}[OK]${NC} Loaded known issues from: $KNOWN_ISSUES_PATH"
 fi
+
+# Build lead agent prompt by querying board state via MCP proxy
+build_lead_prompt() {
+    # Query board state using moe-call.sh if available, otherwise via proxy directly
+    local board_state=""
+    local context_state=""
+    local moe_call="$SCRIPT_DIR/moe-call.sh"
+
+    if [ -f "$moe_call" ]; then
+        board_state=$(bash "$moe_call" list_tasks '{}' --project "$PROJECT" 2>/dev/null || echo "(failed to fetch board state)")
+        context_state=$(bash "$moe_call" get_context '{}' --project "$PROJECT" 2>/dev/null || echo "(failed to fetch context)")
+    else
+        # Fall back to direct proxy invocation
+        local list_rpc='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"moe.list_tasks","arguments":{}}}'
+        local ctx_rpc='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"moe.get_context","arguments":{}}}'
+
+        if [ -n "$PROXY_ARGS" ]; then
+            board_state=$(echo "$list_rpc" | MOE_PROJECT_PATH="$PROJECT" "$NODE_CMD" "$PROXY_ARGS" 2>/dev/null || echo "(failed to fetch board state)")
+            context_state=$(echo "$ctx_rpc" | MOE_PROJECT_PATH="$PROJECT" "$NODE_CMD" "$PROXY_ARGS" 2>/dev/null || echo "(failed to fetch context)")
+        elif [ -n "$PROXY_CMD" ]; then
+            board_state=$(echo "$list_rpc" | MOE_PROJECT_PATH="$PROJECT" "$PROXY_CMD" 2>/dev/null || echo "(failed to fetch board state)")
+            context_state=$(echo "$ctx_rpc" | MOE_PROJECT_PATH="$PROJECT" "$PROXY_CMD" 2>/dev/null || echo "(failed to fetch context)")
+        fi
+    fi
+
+    # Extract columnAgents and columnLimits from context if available
+    local column_agents_section=""
+    local column_limits_section=""
+    if [ -n "$context_state" ] && [ "$context_state" != "(failed to fetch context)" ]; then
+        column_agents_section=$($PYTHON_CMD -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+    settings = None
+    if isinstance(data, dict):
+        proj = data.get('project', {})
+        settings = proj.get('settings', {})
+    if settings:
+        ca = settings.get('columnAgents', {})
+        if ca:
+            lines = ['Column-to-agent role mappings from project settings:']
+            for col, role in ca.items():
+                lines.append(f'  - {col}: spawn {role} teammate')
+            print('\n'.join(lines))
+except:
+    pass
+" <<< "$context_state" 2>/dev/null || true)
+
+        column_limits_section=$($PYTHON_CMD -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+    settings = None
+    if isinstance(data, dict):
+        proj = data.get('project', {})
+        settings = proj.get('settings', {})
+    if settings:
+        cl = settings.get('columnLimits', {})
+        if cl:
+            lines = ['WIP limits from project settings:']
+            for col, limit in cl.items():
+                lines.append(f'  - {col}: max {limit} tasks')
+            print('\n'.join(lines))
+except:
+    pass
+" <<< "$context_state" 2>/dev/null || true)
+    fi
+
+    # Build the dynamic sections
+    local column_agents_block=""
+    if [ -n "$column_agents_section" ]; then
+        column_agents_block="
+## Column Agent Mappings
+$column_agents_section
+Use these mappings instead of the defaults below when spawning teammates."
+    fi
+
+    local wip_limits_block=""
+    if [ -n "$column_limits_section" ]; then
+        wip_limits_block="
+## WIP Limits
+$column_limits_section
+Before spawning a teammate for column X, check that the number of assigned tasks in that column is less than the WIP limit. If at limit, skip spawning for that column."
+    fi
+
+    cat << LEADPROMPTEOF
+You are the lead agent for a Moe AI Workforce session. You coordinate teammates using Claude Agent Teams.
+
+## Your Role
+- You are in DELEGATE MODE: coordinate only, do NOT implement code yourself
+- Spawn teammates for each role needed based on the board state below
+- Monitor progress and re-scan the board periodically
+
+## Current Board State
+$board_state
+
+## Project Context
+$context_state
+$column_agents_block
+$wip_limits_block
+
+## Teammate Spawn Instructions
+For each task needing work, spawn a teammate with the appropriate role:
+- BACKLOG/PLANNING tasks: spawn architect teammate with prompt "You are an architect agent. Claim task {taskId} using moe.claim_next_task, read context with moe.get_context, create a plan, submit with moe.submit_plan, then call moe.wait_for_approval to wait for human approval."
+- WORKING tasks: spawn worker teammate with prompt "You are a worker agent. Claim task {taskId} using moe.claim_next_task, implement the plan step by step using moe.start_step and moe.complete_step, then call moe.complete_task when done."
+- REVIEW tasks: spawn QA teammate with prompt "You are a QA agent. Claim task {taskId} using moe.claim_next_task, review the implementation, run tests, then call moe.qa_approve or moe.qa_reject."
+
+## Moe MCP Tools Reference
+- moe.get_context: Get project, epic, task context
+- moe.claim_next_task: Claim the next available task for your role
+- moe.submit_plan: Submit implementation plan for architect review
+- moe.wait_for_approval: Wait for human to approve/reject your plan
+- moe.start_step: Mark a plan step as in-progress
+- moe.complete_step: Mark a plan step as completed
+- moe.complete_task: Mark task as done
+- moe.qa_approve: QA approves a completed task
+- moe.qa_reject: QA rejects with feedback
+- moe.report_blocked: Report that you are blocked
+- moe.list_tasks: List tasks filtered by status
+- moe.get_pending_questions: Check for unanswered human questions
+- moe.add_comment: Add a comment to a task
+
+All teammates have access to Moe MCP tools via the proxy.
+
+## Periodic Re-scan
+After initial teammate spawning, periodically call moe.list_tasks to check for new work. If tasks have moved between columns, spawn additional teammates as needed. Use moe.list_tasks with different status filters to get a comprehensive view of the board.
+
+## Lifecycle Management
+When all tasks are completed or no more work is available, gracefully shut down all teammates and exit. If new tasks appear on the board after teammates have finished, spawn fresh teammates to handle them.
+
+## Rules
+- Respect WIP limits from project settings
+- Re-scan the board after teammates complete work to find new tasks
+- Shut down teammates when no work remains
+LEADPROMPTEOF
+}
 
 LOOP_ENABLED=true
 if [ "$NO_LOOP" = true ] || [ "$POLL_INTERVAL" -le 0 ] 2>/dev/null; then
@@ -1088,7 +1244,19 @@ Run: bash $moe_call --help for full list."
         echo ""
     fi
 
-    if [ "$CLI_TYPE" = "codex" ]; then
+    if [ "$LEAD_MODE" = true ]; then
+        # Lead mode: build lead prompt and launch with Agent Teams
+        echo -e "${BLUE}Building lead agent prompt...${NC}"
+        LEAD_PROMPT=$(build_lead_prompt)
+        export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+        unset CLAUDECODE
+
+        AGENT_CMD="$COMMAND"
+        echo -e "Starting ${CLI_TYPE} in lead mode (Agent Teams)..."
+        echo ""
+        LEAD_KICK="You are the Moe Lead agent. Start by calling moe.list_tasks to scan the board, then spawn architect teammates for BACKLOG tasks (highest priority first). Monitor progress and spawn worker/QA teammates as tasks move through columns."
+        (cd "$PROJECT" && $AGENT_CMD "$LEAD_KICK" --append-system-prompt "$LEAD_PROMPT" --allowedTools "mcp__moe__*,Bash,Read,Write,Edit,Glob,Grep,Task" --verbose) || true
+    elif [ "$CLI_TYPE" = "codex" ]; then
         # Check codex is available
         if ! command -v "$COMMAND" &> /dev/null; then
             echo -e "${RED}[ERROR]${NC} Codex command not found: $COMMAND. Install codex CLI first."
@@ -1183,6 +1351,7 @@ Run: bash $moe_call --help for full list."
         fi
     else
         # Enable CC Agent Teams for Claude workers when setting is on
+        unset CLAUDECODE
         unset CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
         if [ "$ROLE" = "worker" ] && [ "$ENABLE_AGENT_TEAMS" = "true" ]; then
             export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1


### PR DESCRIPTION
## Summary
- Add board settings panel with configurable WIP limits per column
- New `waitForApproval` MCP tool allowing agents to pause and wait for human approval
- Agent team mode with terminal launcher for multi-agent orchestration
- Deploy script for plugin distribution

## Changes
- **Plugin**: `BoardSettingsPanel`, `TerminalAgentLauncher`, updated Models/Services/UI
- **Daemon**: `waitForApproval` tool with full test coverage (347 lines), schema updates, StateManager enhancements
- **Scripts**: `deploy-plugin.sh`, expanded `moe-agent.sh`

## Test plan
- [ ] Verify daemon tests pass (`cd packages/moe-daemon && npx vitest run`)
- [ ] Verify plugin builds (`cd moe-jetbrains && ./gradlew buildPlugin`)
- [ ] Test WIP limits in board settings UI
- [ ] Test waitForApproval flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)