### PR TITLE
fix(daemon): wait_for_task answers a team-less caller with NO_TEAM_MEMBERSHIP, as claim_next_task does

### DIFF
--- a/packages/moe-daemon/src/tools/waitForTask.test.ts
+++ b/packages/moe-daemon/src/tools/waitForTask.test.ts
@@ -205,9 +205,13 @@ describe('wait_for_task eligibility mirrors claim_next_task (hot-loop regression
     expect(result.taskId).toBe('task-live');
   });
 
-  it('does NOT offer a task blocked by the solo-worker epic+status rule (claim would decline → spin)', async () => {
+  it('does NOT offer a task withheld by the solo-worker epic+status rule — and says WHY, exactly as claim_next_task does', async () => {
     // Live worker A holds task-1 (WORKING) in the epic; teamless worker B waits
-    // on WORKING. claim_next_task would skip task-2, so wait must not wake B.
+    // on WORKING. claim_next_task would skip task-2 and answer NO_TEAM_MEMBERSHIP
+    // with a join_team nextAction. wait must not wake B into that claim (spin),
+    // but it must not park B on a timer either: a bare hasNext:false reads as
+    // "nothing to do" and left a real seat idle through three governor pings
+    // on 2026-09-05 while the row sat claimable for everyone on a team.
     writeTask('task-1', { status: 'WORKING', assignedWorkerId: 'worker-a', order: 1 });
     writeTask('task-2', { status: 'WORKING', assignedWorkerId: null, order: 2 });
     writeWorker('worker-a', { currentTaskId: 'task-1', status: 'CODING' });
@@ -221,6 +225,29 @@ describe('wait_for_task eligibility mirrors claim_next_task (hot-loop regression
     ) as Record<string, unknown>;
 
     expect(result.hasNext).toBe(false);
+    expect(result.task).toBeUndefined();
+    // The remedy, not a timeout: same code and nextAction claim_next_task emits.
+    expect(result.code).toBe('NO_TEAM_MEMBERSHIP');
+    expect((result.nextAction as { tool: string }).tool).toBe('moe.join_team');
+    expect((result.nextAction as { args: { workerId: string } }).args.workerId).toBe('worker-b');
+    expect(result.timedOut).toBeUndefined();
+  });
+
+  it('still times out quietly when the pool is empty for reasons other than team membership', async () => {
+    // Nothing claimable at all: no candidate was withheld by the solo rule, so
+    // the caller gets the ordinary timeout, not a NO_TEAM_MEMBERSHIP it cannot
+    // act on. Guards the discriminator from regressing into "always refuse".
+    writeWorker('worker-b');
+    await state.load();
+
+    const tool = waitForTaskTool(state);
+    const result = await tool.handler(
+      { statuses: ['WORKING'], workerId: 'worker-b', timeoutMs: 1000 },
+      state
+    ) as Record<string, unknown>;
+
+    expect(result.hasNext).toBe(false);
+    expect(result.code).toBeUndefined();
     expect(result.timedOut).toBe(true);
   });
 

--- a/packages/moe-daemon/src/tools/waitForTask.ts
+++ b/packages/moe-daemon/src/tools/waitForTask.ts
@@ -3,7 +3,7 @@ import type { StateManager } from '../state/StateManager.js';
 import type { ChatMessage, TaskPriority } from '../types/schema.js';
 import { missingRequired } from '../util/errors.js';
 import { AGENT_CLAIMABLE_STATUSES, assertAgentClaimableStatuses } from '../util/claimableStatuses.js';
-import { resolveEffectiveTeam } from '../util/teamMembershipHeal.js';
+import { noTeamMembershipRefusal, resolveEffectiveTeam } from '../util/teamMembershipHeal.js';
 import { blockingHold, heldTaskRefusal, isClaimGatedByDependsOn } from '../util/claimEligibility.js';
 import { logger } from '../util/logger.js';
 
@@ -94,12 +94,36 @@ function findPendingQuestion(
   return null;
 }
 
+interface MatchingTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  epicId: string;
+}
+
+interface MatchResult {
+  match: MatchingTask | null;
+  /**
+   * True when the pool had claimable candidates and the solo epic+status rule
+   * removed every one of them. claim_next_task answers that exact case with
+   * NO_TEAM_MEMBERSHIP and a join_team nextAction; wait_for_task used to
+   * answer it with a bare hasNext:false, which reads as "nothing to do" and
+   * parked a team-less seat indefinitely. Measured 2026-09-05: a seat whose
+   * catch-all team was full (join_team refused it) idled through three
+   * governor pings; only a targeted claim ever surfaced the code.
+   */
+  skippedForNoTeam: boolean;
+}
+
+const NO_MATCH: MatchResult = { match: null, skippedForNoTeam: false };
+
 function findMatchingTask(
   state: StateManager,
   statuses: string[],
   epicId?: string,
   workerId?: string
-): { id: string; title: string; status: string; priority: string; epicId: string } | null {
+): MatchResult {
   // The caller's OWN held task wakes the waiter the moment it is in a
   // requested status — this is the un-block resume path: a worker parked on
   // wait_for_task while its task sat BLOCKED must wake when the resource
@@ -115,7 +139,10 @@ function findMatchingTask(
         !(t.status === 'REVIEW' && t.needsHumanReview === true)
     );
     if (own) {
-      return { id: own.id, title: own.title, status: own.status, priority: own.priority, epicId: own.epicId };
+      return {
+        match: { id: own.id, title: own.title, status: own.status, priority: own.priority, epicId: own.epicId },
+        skippedForNoTeam: false
+      };
     }
   }
   // The CALLER's own eligibility is part of that pool and was the one part this
@@ -123,12 +150,12 @@ function findMatchingTask(
   // hold is answered by the own-task match above, while BLOCKED is not
   // agent-claimable and so can never be a requested status. Measured spin,
   // twice in one session (task-9d5dfec6).
-  if (workerId && blockingHold(state, workerId)) return null;
+  if (workerId && blockingHold(state, workerId)) return NO_MATCH;
   // Eligibility here must be at least as strict as claim_next_task's ranked
   // pool: any task that is wait-visible but claim-ineligible wakes the waiter
   // into a claim that declines straight back to wait_for_task — a hot
   // wake→claim→wait spin at full RPC speed for as long as the task persists.
-  const tasks = Array.from(state.tasks.values())
+  const eligible = Array.from(state.tasks.values())
     .filter((t) => statuses.includes(t.status))
     .filter((t) => (epicId ? t.epicId === epicId : true))
     .filter((t) => state.isTaskClaimable(t))
@@ -138,14 +165,16 @@ function findMatchingTask(
     // dependsOn gate (WORKING candidates only) — mirrors claim_next_task's
     // ranked pool via the SAME predicate (util/claimEligibility.ts); a drift
     // here wakes the waiter into a claim that refuses (the measured spin).
-    .filter((t) => !isClaimGatedByDependsOn(state, t))
-    // Single-worker-per-epic-status (solo workers only): claim skips a
-    // candidate when a live OTHER worker holds a different task in the same
-    // epic+status — mirror that too.
+    .filter((t) => !isClaimGatedByDependsOn(state, t));
+  // Single-worker-per-epic-status (solo workers only): claim skips a
+  // candidate when a live OTHER worker holds a different task in the same
+  // epic+status — mirror that too. Effective membership, exactly as
+  // claim_next_task resolves it: an evicted team member must not go
+  // invisible here and park forever.
+  const solo = Boolean(workerId) && !resolveEffectiveTeam(state, workerId as string);
+  const tasks = eligible
     .filter((t) => {
-      // Effective membership, exactly as claim_next_task resolves it: an
-      // evicted team member must not go invisible here and park forever.
-      if (!workerId || resolveEffectiveTeam(state, workerId)) return true;
+      if (!solo) return true;
       const otherActiveOnSameStatus = Array.from(state.tasks.values()).some((o) =>
         o.id !== t.id &&
         o.epicId === t.epicId &&
@@ -164,8 +193,17 @@ function findMatchingTask(
     });
 
   const task = tasks[0];
-  if (!task) return null;
-  return { id: task.id, title: task.title, status: task.status, priority: task.priority, epicId: task.epicId };
+  if (!task) {
+    // Same two dead ends claim_next_task distinguishes: an empty pool, or a
+    // pool the solo rule alone emptied. Only the second has a remedy the
+    // caller can act on, and hiding it behind hasNext:false is what parked
+    // team-less seats — report it so the caller reaches join_team.
+    return { match: null, skippedForNoTeam: solo && eligible.length > 0 };
+  }
+  return {
+    match: { id: task.id, title: task.title, status: task.status, priority: task.priority, epicId: task.epicId },
+    skippedForNoTeam: false
+  };
 }
 
 export function waitForTaskTool(_state: StateManager): ToolDefinition {
@@ -214,16 +252,23 @@ export function waitForTaskTool(_state: StateManager): ToolDefinition {
 
       // Check if a matching task already exists
       const immediate = findMatchingTask(state, statuses, params.epicId, workerId);
-      if (immediate) {
+      if (immediate.match) {
         return {
           hasNext: true,
-          task: immediate,
+          task: immediate.match,
           nextAction: {
             tool: 'moe.claim_next_task',
             args: { statuses, workerId, epicId: params.epicId },
             reason: 'Task is available; claim it, then call moe.get_context.'
           }
         };
+      }
+      // Work exists but the caller is team-less and the solo epic+status rule
+      // withheld all of it. Answer exactly as claim_next_task does — with the
+      // code and the join_team nextAction — instead of parking the caller on a
+      // timer it cannot escape by waiting.
+      if (immediate.skippedForNoTeam) {
+        return noTeamMembershipRefusal(workerId);
       }
 
       // Check if any task has a pending question
@@ -334,19 +379,28 @@ export function waitForTaskTool(_state: StateManager): ToolDefinition {
           // Only react to task creation/update events
           if (event.type !== 'TASK_CREATED' && event.type !== 'TASK_UPDATED') return;
 
-          const match = findMatchingTask(state, statuses, params.epicId, workerId);
-          if (match) {
+          const found = findMatchingTask(state, statuses, params.epicId, workerId);
+          if (found.match) {
             cleanup();
-            logger.info({ workerId, taskId: match.id }, 'Task available, waking worker');
+            logger.info({ workerId, taskId: found.match.id }, 'Task available, waking worker');
             resolve({
               hasNext: true,
-              task: match,
+              task: found.match,
               nextAction: {
                 tool: 'moe.claim_next_task',
                 args: { statuses, workerId, epicId: params.epicId },
                 reason: 'Matching task appeared; claim it, then call moe.get_context.'
               }
             });
+            return;
+          }
+          // A task appeared that only team membership keeps from this caller:
+          // wake it with the remedy rather than leaving it asleep while the
+          // row sits claimable for everyone else.
+          if (found.skippedForNoTeam) {
+            cleanup();
+            logger.info({ workerId }, 'Claimable work withheld by the solo epic+status rule; waking worker with NO_TEAM_MEMBERSHIP');
+            resolve(noTeamMembershipRefusal(workerId));
             return;
           }
 


### PR DESCRIPTION
## Defect

A worker spawned as the 11th seat on a full catch-all team (`maxSize: 10`) idled through three governor pings while a claimable row sat in front of it. Its wait loop only ever returned `{ hasNext: false, hasChatMessage: true }`. A targeted claim was the first thing to say why:

```
claim_next_task -> {"hasNext":false,"code":"NO_TEAM_MEMBERSHIP","nextAction":{"tool":"moe.join_team", ... }}
join_team       -> Mcp error -32000: Team moe-next is full (max 10 members)
```

Both tools apply the same solo epic+status filter, and `waitForTask.ts`'s own comments say they must stay in lockstep. They did not: `claim_next_task` tracks `skippedForNoTeam` and returns `noTeamMembershipRefusal`; `findMatchingTask` applied the identical filter and returned `null`, so `wait_for_task` fell through to a bare `hasNext:false`. To the wrapper's no-task loop that reads as "nothing to do", and a team-less seat parks on a timer it cannot escape by waiting. `teamMembershipHeal` cannot rejoin a seat to a team that filled up, so nothing self-corrected.

## Fix

`findMatchingTask` returns `{ match, skippedForNoTeam }`; the flag is true only when candidates survived every other filter and the solo rule removed all of them. Both callers (entry check and the `TASK_CREATED`/`TASK_UPDATED` wake) return `noTeamMembershipRefusal(workerId)` in that case — the same payload `claim_next_task` emits — and the wake path cleans up the waiter. An empty pool for any other reason still times out quietly.

## Tests

- Existing solo-rule arm updated from the old contract (`timedOut: true`) to assert `code: NO_TEAM_MEMBERSHIP`, `nextAction.tool: moe.join_team` with the caller's `workerId`, and no timeout.
- New arm: empty pool with no solo withholding still times out with no `code` — guards the discriminator from regressing into "always refuse".

`tsc --noEmit` exit 0. `vitest` over `waitForTask`, `claimNextTask`, `claimNextTask.contract`, `teamMembershipHeal`: **4 files passed, 71 tests passed**.

## Not in this PR

`join_team`'s "team is full" error carries no `nextAction`, so a seat that reaches it still dead-ends. Worth a follow-up hint toward `moe.list_teams` / `moe.create_team`; kept out to keep this change scoped to the wait/claim parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)