### PR TITLE
fix(daemon): chat_wait applies an explicit sinceId only to the channel that holds it

### DIFF
--- a/packages/moe-daemon/src/tools/chatWait.test.ts
+++ b/packages/moe-daemon/src/tools/chatWait.test.ts
@@ -177,6 +177,20 @@ describe('moe.chat_wait', () => {
       expect(result.messages?.map((m) => m.id)).toEqual([second.id, third.id]);
     });
 
+    it('applies the id only to the channel that holds it; other channels keep their stored cursor', async () => {
+      const a1 = await post(channels.general, 'a1', 'system');
+      const a2 = await post(channels.general, 'a2', 'system');
+      await post(channels.workers, 'b1', 'system');
+      const b2 = await post(channels.workers, 'b2', 'system');
+      await state.updateWorkerCursors(WORKER_ID, { [channels.general]: a2.id, [channels.workers]: b2.id });
+
+      const result = await wait({ channels: [channels.general, channels.workers], sinceId: a1.id });
+
+      // Before the fix #workers replayed b1 and b2: the foreign id hit the
+      // expired-cursor fallback and the whole channel window came back.
+      expect(result.messages?.map((m) => m.id)).toEqual([a2.id]);
+    });
+
     it('rejects an empty sinceId', async () => {
       await expect(wait({ channels: [channels.general], sinceId: '' }))
         .rejects.toMatchObject({ context: { field: 'sinceId' } });

--- a/packages/moe-daemon/src/util/chatBacklog.ts
+++ b/packages/moe-daemon/src/util/chatBacklog.ts
@@ -163,7 +163,13 @@ export async function collectChatBacklog(
   const scannedChannels = new Set<string>();
 
   for (const channelId of channelIds) {
-    const sinceId = explicitSinceId ?? worker?.chatCursors?.[channelId];
+    // An explicit catch-up id belongs to ONE channel. Applying it to a channel
+    // that does not hold it would trip getMessages' expired-cursor fallback and
+    // replay that channel's whole window on every call; those channels keep
+    // their stored cursor instead.
+    const sinceId = explicitSinceId && state.messageExistsInChannel(channelId, explicitSinceId)
+      ? explicitSinceId
+      : worker?.chatCursors?.[channelId];
     try {
       const messages = await state.getMessages(channelId, { sinceId, limit: PER_CHANNEL_SCAN_LIMIT });
       scannedChannels.add(channelId);


### PR DESCRIPTION
## Summary
- `collectChatBacklog` applied the caller's `sinceId` to every watched channel; in a channel that does not hold that id, `getMessages` falls back to the whole bounded window, so a multi-channel `chat_wait { sinceId }` replayed weeks of foreign-channel backlog on every call.
- Channels that do not hold the id now keep their stored cursor; the channel that holds it still catches up from it.

## Test plan
- [x] `npx tsc --noEmit -p .` in `packages/moe-daemon` exit 0
- [x] `npx vitest run src/tools/chatWait.test.ts src/tools/chatBudgets.test.ts` 27 passed
- [x] New arm fails with the source change stashed (drill), passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
