### PR TITLE
fix(onboarding): provision dependencies and recover agent launches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  fresh-linux-install:
+    name: Fresh Linux installation
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      # Deliberately omit setup-node: the public installer must supply its dependencies.
+      - name: Install dependencies and build Moe
+        run: bash scripts/install-mac.sh --global --skip-mcp --agent claude
+
+      - name: Verify installed commands and first project
+        shell: bash
+        run: |
+          . "$HOME/.local/share/moe/env.sh"
+          command -v moe-daemon
+          command -v moe-proxy
+          claude --version
+          node scripts/tests/onboarding.mjs
+
   build-typescript:
     name: Build TypeScript
     runs-on: ubuntu-latest
@@ -16,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: |
             packages/moe-daemon/package-lock.json
@@ -55,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: |
             packages/moe-daemon/package-lock.json
@@ -108,7 +128,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: |
             packages/moe-daemon/package-lock.json
@@ -146,6 +166,11 @@ jobs:
         run: ./gradlew test
         working-directory: moe-jetbrains
 
+      - name: Verify packaged JetBrains onboarding
+        run: |
+          unzip -q moe-jetbrains/build/distributions/*.zip -d "$RUNNER_TEMP/moe-plugin-smoke"
+          node scripts/tests/onboarding.mjs "$RUNNER_TEMP/moe-plugin-smoke/moe-jetbrains"
+
       - name: Upload plugin zip
         uses: actions/upload-artifact@v7
         with:
@@ -165,7 +190,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Build daemon
         run: |
@@ -178,3 +203,21 @@ jobs:
           npm install --no-audit --no-fund
           npm run build
         working-directory: packages/moe-proxy
+
+      - name: Verify fresh project onboarding
+        run: node scripts/tests/onboarding.mjs
+
+      - name: Test release version guard
+        run: node --test scripts/tests/release-version.mjs
+
+      - name: Test installers with isolated profiles
+        run: node --test scripts/tests/installers.test.mjs scripts/tests/install-dependencies-windows.test.mjs scripts/tests/dependencies.test.mjs
+
+      - name: Test agent runtime discovery
+        run: node --test scripts/tests/agent-runtime.test.mjs
+
+      - name: Test VS Code daemon startup
+        run: |
+          npm ci
+          npm test
+        working-directory: moe-vscode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,21 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
+    env:
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup JDK
@@ -32,6 +35,9 @@ jobs:
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Verify release versions
+        run: node scripts/verify-release-version.mjs "$GITHUB_REF_NAME"
 
       # Build TypeScript packages
       - name: Build daemon
@@ -46,6 +52,9 @@ jobs:
           npm run build
         working-directory: packages/moe-proxy
 
+      - name: Verify fresh project onboarding
+        run: node scripts/tests/onboarding.mjs
+
       # Build JetBrains plugin
       - name: Build plugin
         run: ./gradlew buildPlugin
@@ -58,16 +67,23 @@ jobs:
           npm run package
         working-directory: moe-vscode
 
+      - name: Verify packaged onboarding
+        run: |
+          unzip -q moe-jetbrains/build/distributions/*.zip -d "$RUNNER_TEMP/moe-plugin-smoke"
+          node scripts/tests/onboarding.mjs "$RUNNER_TEMP/moe-plugin-smoke/moe-jetbrains"
+          unzip -q moe-vscode/*.vsix -d "$RUNNER_TEMP/moe-vscode-smoke"
+          node scripts/tests/onboarding.mjs "$RUNNER_TEMP/moe-vscode-smoke/extension/bundled"
+
       # Publish to npm (when NPM_TOKEN is configured)
       - name: Publish daemon to npm
-        if: env.NPM_TOKEN != ''
+        if: env.HAS_NPM_TOKEN == 'true'
         run: npm publish --access public --provenance
         working-directory: packages/moe-daemon
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish proxy to npm
-        if: env.NPM_TOKEN != ''
+        if: env.HAS_NPM_TOKEN == 'true'
         run: npm publish --access public --provenance
         working-directory: packages/moe-proxy
         env:
@@ -89,13 +105,15 @@ jobs:
     name: Publish to JetBrains Marketplace
     runs-on: ubuntu-latest
     needs: build-and-release
+    env:
+      HAS_PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: packages/moe-daemon/package-lock.json
 
@@ -105,6 +123,12 @@ jobs:
           npm run build
         working-directory: packages/moe-daemon
 
+      - name: Build proxy
+        run: |
+          npm ci
+          npm run build
+        working-directory: packages/moe-proxy
+
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
@@ -113,9 +137,8 @@ jobs:
           cache: 'gradle'
 
       - name: Publish plugin
-        if: ${{ env.PUBLISH_TOKEN != '' }}
+        if: env.HAS_PUBLISH_TOKEN == 'true'
         run: ./gradlew publishPlugin
         working-directory: moe-jetbrains
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-        continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ cd moe-vscode          && npm install && npm run package  # .vsix via vsce (comp
 
 Both IDE plugin builds hard-fail unless daemon AND proxy each have `dist/` **and** `node_modules/` — npm install + build both first. Role-doc/skill edits reach IDE users only through a plugin rebuild (they're bundled into the plugin, then force-synced into each project's `.moe/`).
 
-Windows full install (daemon + proxy + JetBrains plugin): `.\scripts\install-all.ps1`
+Windows full build (daemon + proxy + JetBrains plugin ZIP): `.\scripts\install-all.ps1 -BuildPlugin`
 
 ## Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Roles: **architect** plans (`submit_plan`), **worker** codes per-step, **QA** re
 | `packages/moe-proxy/` | TS (Node, ESM) | MCP stdio shim. Agent CLI speaks MCP over stdio; proxy forwards to the daemon over `ws://127.0.0.1:<port>/mcp` (reconnects, per-message timeouts). Injects `workerId` (from `MOE_WORKER_ID`, set by the launchers) into every `tools/call` that omits it. |
 | `packages/moe-claude-plugin/` | TS (Node, ESM) | Claude Code plugin: slash commands + PostToolUse hook forwarding `moe.*` tool events to the daemon's `/ws` (fire-and-forget, fail-open; opt out `MOE_DISABLE_TOOL_HOOK=1`). The hook shim imports `dist/` (not committed) and swallows errors — src edits are silently inert until `npm run build`. |
 | `moe-jetbrains/` | Kotlin/Swing | Primary plugin. Bundles daemon+proxy+scripts+role docs+skills; auto-spawns the daemon on project open (and kills it on close if it's the last project using that PID; override resolution via `MOE_DAEMON_COMMAND`/`MOE_NODE_COMMAND`). Tool window with a 5-column board over `/ws` — AWAITING_APPROVAL is display-mapped into the Planning column, not a column of its own. |
-| `moe-vscode/` | TS | VS Code / Antigravity extension (secondary). Also bundles daemon+proxy+scripts and auto-spawns the daemon; registers the bundled proxy as an MCP server on Antigravity. No automated tests (MANUAL_TESTS.md only). |
+| `moe-vscode/` | TS | VS Code / Antigravity extension (secondary). Also bundles daemon+proxy+scripts and auto-spawns the daemon; registers the bundled proxy as an MCP server on Antigravity. `npm test` covers daemon startup; MANUAL_TESTS.md covers IDE interaction. |
 
 Daemon, proxy, and claude-plugin each build with `tsc` and test with `vitest`. There are **no npm workspaces** — install/build per package. Root `package.json` only has `npm run lint` (role-doc linter).
 
@@ -68,6 +68,7 @@ cd packages/moe-daemon && npm test                                  # vitest run
 cd packages/moe-daemon && npx vitest run src/server/McpAdapter.test.ts   # single file
 cd packages/moe-daemon && npx vitest run -t "<test name>"                # single test by name
 cd moe-jetbrains       && ./gradlew test                            # plugin unit tests (JUnit 4, headless — a CI merge gate)
+cd moe-vscode          && npm test && npm run compile                # startup regression tests + typecheck
 bash scripts/tests/postflight.sh                                    # launcher-script harness (daemon-free; .ps1 sibling for PowerShell)
 bash scripts/tests/parity-check.sh                                  # ps1/sh wrapper string parity (codes, banners, settings keys, env names)
 npm run lint                                                        # repo root: role-doc linter (bash script — Git Bash on Windows)

--- a/README.md
+++ b/README.md
@@ -69,71 +69,62 @@ AI coding agents are powerful but need guardrails. **Moe's Tavern** provides:
 
 ## Quick Start
 
-### Prerequisites
+Start with one small task in a Git project. This walkthrough builds Moe from source and uses the **JetBrains board** to create tasks and approve plans. Follow the [first-task guide](docs/GETTING_STARTED.md) for every step, checks, and fixes for common setup problems.
 
-- **Node.js 18+** - [Download](https://nodejs.org/)
-- **JetBrains IDE** (optional) - For visual Kanban board
+### 1. Download Moe
 
-### Installation
+Download the [source ZIP](https://github.com/yaront1111/Moe-s-Tavern/archive/refs/heads/main.zip), extract it, and open a terminal in the extracted Moe folder. You can also clone the repository if Git is already installed.
 
-**Windows:**
+Use a JetBrains IDE for the board. Automatic dependency installation supports **Windows with WinGet**, **macOS with Homebrew and Command Line Tools**, and **Linux with apt-get or dnf**. System package installation may ask for your operating system password or permission.
+
+### 2. Install Moe from source
+
+Run one command below. The installer handles missing Node.js/npm, Git, the selected coding CLI, and JDK 17, then builds Moe and the board plugin. On macOS/Linux it also installs Python3 and download tools; Linux includes tmux for terminal-based teams. Keep this folder: the agent launch scripts live here.
+
+**Windows (PowerShell):**
 ```powershell
-git clone https://github.com/yaront1111/Moe-s-Tavern.git
-cd Moe-s-Tavern
-.\scripts\install-all.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-all.ps1 -BuildPlugin
 ```
 
-**Mac / Linux:**
+**macOS / Linux (Bash):**
 ```bash
-git clone https://github.com/yaront1111/Moe-s-Tavern.git
-cd Moe-s-Tavern
-chmod +x scripts/*.sh
-./scripts/install-mac.sh
+bash scripts/install-mac.sh --global --skip-mcp --with-plugin
 ```
 
-### Initialize a Project
+Claude Code is the default. To install Codex instead, add `-AgentCommand codex` on Windows or `--agent codex` on macOS/Linux; `gemini` and `none` are also available. Open a new terminal after installation and run your selected CLI once in your target project to sign in. Moe cannot sign in to your provider account for you.
 
-```bash
-# Navigate to your project and initialize
-cd /path/to/your/project
-moe-daemon init
+In your IDE, open **Settings / Preferences → Plugins → gear icon → Install Plugin from Disk**, select the ZIP in `moe-jetbrains/build/distributions/`, and restart. Use this freshly built plugin; published release downloads may contain an older implementation. See the [first-task guide](docs/GETTING_STARTED.md) if installation reports a missing package manager or PATH problem.
 
-# Or specify the path explicitly
-moe-daemon init --project /path/to/project --name "My Project"
+### 3. Open your project and create a task
+
+1. Open **your target Git project** in JetBrains and open the **Moe** tool window. The plugin initializes `.moe/` and starts the daemon. Wait for **Connected**.
+2. Open **Project Settings** and keep **Approval Mode: CONTROL** so you review the plan before implementation.
+3. Click **+ Epic**, create an epic such as `First task`, then use the **+** in its **Backlog** column to create a task. Give it a clear title, description, and Definition of Done. For example: add a `GETTING_STARTED.md` containing the project's verified setup and test commands.
+4. Drag the task from **Backlog** to **Planning**. Architects claim tasks in Planning; an empty board or a task left in Backlog gives them nothing to plan.
+
+### 4. Plan, approve, implement, and review
+
+In the board's **Agents** menu, choose **Architect**, then your installed CLI. When the task shows **Awaiting Approval** in the Planning column, open it, read the plan, and click **Approve**. Then launch **Worker** and **QA** from the same menu. Keep their terminals open while they work.
+
+To launch from a terminal instead, open a **new terminal in the Moe-s-Tavern checkout**, then run one role per terminal:
+
+```powershell
+# Windows; change architect to worker or qa for the next roles
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\moe-agent.ps1 -Role architect -Project "C:\your\project"
 ```
-
-This creates the `.moe/` folder structure with project settings and starts the daemon.
-Stop it with `Ctrl+C` or `moe-daemon stop --project /path/to/project` if you only want initialization.
-
-### Run Your First Agent
-
-```bash
-# Windows
-.\scripts\moe-agent.ps1 -Role architect -Project "C:\your\project"
-
-# Mac / Linux
-./scripts/moe-agent.sh --role architect --project /your/project
-```
-
-The agent will:
-1. Connect to the daemon and load the per-role skills from `.moe/skills/`
-2. Claim a task from the board
-3. Submit a plan for your approval (architect) or execute steps (worker)
-4. Run pre-flight and post-flight checks — including the branch-safety guard that refuses to commit on `main` and peels onto `moe/work-<YYYY-MM-DD>`
-
-Claude-CLI–backed sessions are launched with `--effort max` by default. The agent process respawns per task so prompt size and memory stay bounded across long runs.
-
-### Run a Full Team
-
-Launch architect + worker + QA agents in parallel:
 
 ```bash
-# Windows
-.\scripts\moe-team.ps1 -Project "C:\your\project"
-
-# Mac / Linux
-./scripts/moe-team.sh --project /your/project
+# macOS / Linux; change architect to worker or qa for the next roles
+./scripts/moe-agent.sh --role architect --project "/your/project"
 ```
+
+These examples use Claude Code. For Codex, add `-Command codex` on Windows or `--command codex` on macOS/Linux. The launch scripts start the daemon if needed. For explicit initialization, run `moe-daemon init --project "/your/project"` in its own terminal; it keeps running until stopped.
+
+### 5. Check the result
+
+The task should move through **Working → Review → Done**. Open it to inspect the implementation steps, verification result, and QA summary, then review the changed files and recorded commit in Git. By default the launchers commit task changes and attempt to push them; review any reported Git or verification failure before treating the task as delivered.
+
+If a step stalls, use the [first-task troubleshooting guide](docs/GETTING_STARTED.md#when-a-step-does-not-work). Once one task completes, use **Agents → All Agents** to start the team together.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,143 @@
+# Your first task with Moe
+
+This guide takes a local Git project from installation to one reviewed task using the JetBrains board. Build Moe and its plugin from the same source checkout so the daemon, board, and agent scripts match.
+
+## Download and install
+
+Download the [source ZIP](https://github.com/yaront1111/Moe-s-Tavern/archive/refs/heads/main.zip) and extract it. Open a terminal in the extracted `Moe-s-Tavern-main` folder. If you already have Git, cloning the repository is another way to get the same sources.
+
+The installer supports Windows with WinGet, macOS with Homebrew and Command Line Tools, and Linux with apt-get or dnf. macOS/Linux support x64 and ARM64. Have a JetBrains IDE available for the board. System dependency installation may request your operating system password or permission; the installer stops if your system cannot provide a required package.
+
+The **Moe checkout** below is the folder containing Moe's `scripts/` and `packages/`. Your **target project** is the repository the agents will work on. They can be different folders.
+
+## Install and open the board
+
+From the extracted Moe folder, run:
+
+**Windows — PowerShell:**
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-all.ps1 -BuildPlugin
+```
+
+**macOS / Linux — Bash:**
+
+```bash
+bash scripts/install-mac.sh --global --skip-mcp --with-plugin
+```
+
+The installer installs missing Node.js/npm, Git, the selected agent CLI, and JDK 17, then builds the daemon, proxy, and plugin. macOS/Linux also provision Python3, curl, and tar; Linux installs tmux for team terminals. Existing supported tools are reused. Node 18 is upgraded because current build tools require newer Node.js.
+
+Claude Code is installed by default. To choose another CLI, add `-AgentCommand codex` or `-AgentCommand gemini` on Windows; add `--agent codex` or `--agent gemini` on macOS/Linux. Use `none` to skip provider CLI installation.
+
+`--skip-mcp` leaves project MCP setup to the agent launcher. Keep the Moe folder on disk. New terminals load the installed command paths; on macOS/Linux, refresh an already open terminal with:
+
+```bash
+. "$HOME/.local/share/moe/env.sh"
+```
+
+In your IDE, open **Settings / Preferences → Plugins → gear icon → Install Plugin from Disk**, select the ZIP in `moe-jetbrains/build/distributions/`, and restart. Open **your target project**, then its **Moe** tool window. The plugin creates `.moe/`, starts the daemon, and shows **Connected** with an empty board.
+
+In a new terminal, open your target project and run your chosen CLI (`claude`, `codex`, or `gemini`) once to complete sign-in. Confirm it responds. You need access to that provider; the installer does not perform account sign-in. Check `git status`, `git config user.name`, and `git config user.email` in this project before launching agents. Moe's default launchers commit task changes and attempt to push them to the project's remote.
+
+Run this in another terminal, replacing the path with your target project, to check the daemon:
+
+```bash
+moe-daemon status --project "/path/to/your/project"
+moe-daemon doctor --project "/path/to/your/project"
+```
+
+On Windows, use a quoted Windows path such as `"C:\code\my-project"`. `status` should report the running daemon; `doctor` should finish without hard failures.
+
+## Create one small task
+
+1. Open the board's **Project Settings** and keep **Approval Mode: CONTROL**. This requires you to approve an implementation plan.
+2. Click **+ Epic** and create `First task`.
+3. Use the **+** in that epic's **Backlog** column to open **Create Task**, and select your epic.
+4. Enter a title, description, and Definition of Done. For a small documentation task, use:
+
+   **Title:** Document how to run this project
+
+   **Description:** Inspect the existing project configuration and add `GETTING_STARTED.md` with the setup, run, and test commands that actually exist in this repository.
+
+   **Definition of Done:** The guide contains verified commands, records any required prerequisites, and its relative links resolve. Existing files and behavior remain unchanged.
+
+5. Create the task and drag it into **Planning**. Creation puts a task in Backlog; moving it to Planning makes it available to an architect.
+
+## Launch an architect and approve the plan
+
+Use **Agents → Architect → your installed CLI** in the board. A terminal opens and the architect claims the Planning task. Leave that terminal open.
+
+If you prefer an external terminal, open it in the **Moe checkout** and run:
+
+**Windows:**
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\moe-agent.ps1 -Role architect -Project "C:\code\my-project"
+```
+
+**macOS / Linux:**
+
+```bash
+./scripts/moe-agent.sh --role architect --project "/path/to/my-project"
+```
+
+These commands default to Claude Code. To use Codex, add `-Command codex` or `--command codex`, respectively. The launcher sets up the project's MCP connection and starts the daemon when needed.
+
+Wait for **Awaiting Approval** on the task card in the **Planning** column. Open the task, read its steps and affected files, then click **Approve** if the plan matches your request. If it needs changes, reject it with specific feedback. No implementation should start while the plan is waiting for your approval in CONTROL mode.
+
+## Run the worker and QA
+
+After approving the plan, choose **Agents → Worker → your CLI**, then **Agents → QA → your CLI**. For external terminals, run the architect command above in two more terminals, replacing `architect` with `worker` and `qa`. Keep these terminals open during the task.
+
+The worker implements the steps and runs verification, then submits the task to **Review**. QA reviews the result and can return it to the worker for fixes. A successful review moves it to **Done**.
+
+Open the task and check its completed steps, verification output, QA summary, and recorded commit. Review the actual changed files in your project's Git history. A commit or push failure in the agent terminal needs attention even if the board has advanced.
+
+Once this works, **Agents → All Agents** launches the roles together for subsequent tasks.
+
+## When a step does not work
+
+### Commands not found or global install permission errors
+
+If `moe-daemon` is missing, check `npm prefix -g` and ensure the npm global command directory is on PATH. On Windows this is the prefix itself; on macOS/Linux it is the prefix's `bin` directory. Open a new terminal after changing PATH.
+
+On macOS/Linux the installer selects its own user prefix when the current global prefix is not writable. It preserves your npm configuration. To load its tool paths in an existing terminal:
+
+```bash
+. "$HOME/.local/share/moe/env.sh"
+```
+
+If you use a Node version manager, check that your shell has loaded its configuration. Rerun the installer if the terminal still cannot find the tools.
+
+You can also run the daemon directly from the **Moe checkout**, without global registration:
+
+```bash
+node packages/moe-daemon/dist/index.js status --project "/path/to/your/project"
+```
+
+The agent launch scripts also use the built files directly. Replace `status` with `doctor` or `init` as needed. `init` initializes the target and **keeps the daemon running**; use a separate terminal for other commands or stop it with Ctrl+C.
+
+### The board is disconnected
+
+Run `moe-daemon doctor --project "/path/to/your/project"` and follow its specific failures. Check that Node is available to the IDE; restart the IDE after installing Node or changing PATH. Check that the ZIP came from this checkout's successful plugin build. See [Troubleshooting](TROUBLESHOOTING.md#plugin-issues) for connection diagnostics.
+
+### The agent cannot start or asks to sign in
+
+Run your selected CLI directly in your target project, complete its sign-in/setup, then relaunch it from Moe. The terminal must be able to find that CLI. If `./scripts/moe-agent.sh` or `.\scripts\moe-agent.ps1` is missing, you are probably in the target project: open a terminal in the Moe checkout instead.
+
+### The installer cannot find a package manager
+
+Windows needs WinGet; macOS needs [Homebrew](https://brew.sh) and its Command Line Tools prerequisites. Linux automatic provisioning uses apt-get or dnf. On other distributions, install the dependencies named in the error through your distribution's package manager, then retry. This error means installation has not completed.
+
+### The agent is idle or the task is waiting
+
+- **Backlog:** drag the task to Planning before starting the architect.
+- **Awaiting Approval:** open the task and approve the plan in CONTROL mode.
+- **Working:** ensure a Worker terminal is running and inspect its output.
+- **Review:** ensure QA is running and inspect its output.
+- **Blocked:** read the task's reason and resolve the reported prerequisite before continuing.
+
+### The task changed files but a commit or push failed
+
+Read the agent terminal's Git error and check your project's Git identity, branch, remote, and authentication. Inspect the task's recorded commit evidence before treating it as delivered. Do not delete the working files to clear a board status.

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,32 +94,30 @@
     <section class="getting-started" id="getting-started">
         <div class="container">
             <h2>Getting Started</h2>
+            <p><a href="https://github.com/yaront1111/Moe-s-Tavern/archive/refs/heads/main.zip">Download the source ZIP</a>, extract it, and open a terminal in the extracted Moe folder. The installer handles missing dependencies, installs your coding CLI, and builds Moe and the board plugin.</p>
+            <p>Use a JetBrains IDE for the board. Automatic dependency installation supports Windows with WinGet, macOS with Homebrew and Command Line Tools, and Linux with apt-get or dnf. It may request operating system permission to install system packages.</p>
 
             <div class="platform-tabs">
                 <div class="tab-content">
                     <h3>Windows</h3>
-                    <pre><code>git clone https://github.com/yaront1111/Moe-s-Tavern.git
-cd Moe-s-Tavern
-.\scripts\install-all.ps1</code></pre>
+                    <pre><code>powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-all.ps1 -BuildPlugin</code></pre>
 
                     <h3>Mac / Linux</h3>
-                    <pre><code>git clone https://github.com/yaront1111/Moe-s-Tavern.git
-cd Moe-s-Tavern
-chmod +x scripts/*.sh
-./scripts/install-mac.sh</code></pre>
+                    <pre><code>bash scripts/install-mac.sh --global --skip-mcp --with-plugin</code></pre>
                 </div>
             </div>
 
-            <h3>Initialize Your Project</h3>
-            <pre><code>cd /path/to/your/project
-moe-daemon init</code></pre>
-
-            <h3>Run Your First Agent</h3>
-            <pre><code># Windows
-.\scripts\moe-agent.ps1 -Role architect -Project "C:\your\project"
-
-# Mac / Linux
-./scripts/moe-agent.sh --role architect --project /your/project</code></pre>
+            <h3>Open the board and complete a task</h3>
+            <ol>
+                <li>Install the ZIP from <code>moe-jetbrains/build/distributions/</code> through your IDE's <strong>Plugins → Install Plugin from Disk</strong> menu and restart. Run your CLI once to sign in. Open your target project and its Moe tool window; wait for <strong>Connected</strong>.</li>
+                <li>Keep <strong>Approval Mode: CONTROL</strong> in Project Settings. Click <strong>+ Epic</strong>, then use the <strong>+</strong> in its Backlog column to create one small task with a description and Definition of Done.</li>
+                <li>Drag the task to <strong>Planning</strong>. Choose <strong>Agents → Architect → your CLI</strong>.</li>
+                <li>When the task shows <strong>Awaiting Approval</strong>, open it, read the plan, and click <strong>Approve</strong>.</li>
+                <li>Launch <strong>Worker</strong> and <strong>QA</strong> from the Agents menu. Keep their terminals open.</li>
+                <li>Follow <strong>Working → Review → Done</strong>, then inspect the verification result, QA summary, changed files, and recorded Git commit.</li>
+            </ol>
+            <p>Moe's launchers commit task changes and attempt to push them by default. Review any reported Git or verification failure before treating a task as delivered.</p>
+            <p><a href="https://github.com/yaront1111/Moe-s-Tavern/blob/main/docs/GETTING_STARTED.md">Follow the full first-task guide</a> for exact commands, CLI selection, PATH fixes, and troubleshooting. Published release downloads may contain an older implementation than the source checkout.</p>
         </div>
     </section>
 

--- a/moe-jetbrains/build.gradle.kts
+++ b/moe-jetbrains/build.gradle.kts
@@ -28,6 +28,7 @@ val bundledProxyModules = repoRoot.resolve("packages/moe-proxy/node_modules")
 val bundledProxyMarker = bundledProxyModules.resolve("ws")
 val bundledAgentScript = repoRoot.resolve("scripts/moe-agent.ps1")
 val bundledAgentScriptSh = repoRoot.resolve("scripts/moe-agent.sh")
+val bundledCallScriptSh = repoRoot.resolve("scripts/moe-call.sh")
 val bundledRoleDocs = repoRoot.resolve("docs/roles")
 val bundledAgentContext = repoRoot.resolve("docs/agent-context.md")
 val bundledSkillsDir = repoRoot.resolve("docs/skills")
@@ -74,6 +75,9 @@ fun requireBundledAssets() {
     }
     check(bundledAgentScriptSh.exists()) {
         "Bundled moe-agent.sh not found at ${bundledAgentScriptSh}."
+    }
+    check(bundledCallScriptSh.exists()) {
+        "Bundled moe-call.sh not found at ${bundledCallScriptSh}."
     }
 }
 
@@ -158,7 +162,7 @@ tasks.named<PrepareSandboxTask>("prepareSandbox") {
     from(bundledAgentScript) {
         into("$pluginContentRoot/scripts")
     }
-    from(bundledAgentScriptSh) {
+    from(listOf(bundledAgentScriptSh, bundledCallScriptSh)) {
         into("$pluginContentRoot/scripts")
         // A CRLF working-tree checkout (core.autocrlf) would ship a script WSL bash can't parse.
         filter(

--- a/moe-jetbrains/src/main/kotlin/com/moe/services/MoeDaemonSupervisor.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/services/MoeDaemonSupervisor.kt
@@ -105,12 +105,8 @@ class MoeDaemonSupervisor(
                 }
             }
             pb.redirectErrorStream(true)
-            val nodeDir = direct?.firstOrNull()?.let { File(it).parentFile }
-            if (nodeDir != null) {
-                val env = pb.environment()
-                val current = env["PATH"] ?: ""
-                env["PATH"] = "${nodeDir.absolutePath}${File.pathSeparator}$current"
-            }
+            val env = pb.environment()
+            env["PATH"] = daemonPath(env["PATH"] ?: "", direct?.firstOrNull())
             val process = processStarter(pb)
             val oldProcess = spawnedDaemonProcess
             if (oldProcess != null) {
@@ -272,16 +268,43 @@ class MoeDaemonSupervisor(
         return null
     }
 
-    private fun resolveNodeExecutable(): String? {
-        val env = System.getenv("MOE_NODE_COMMAND")?.trim()
+    internal fun daemonPath(
+        current: String,
+        nodeCommand: String?,
+        home: String? = System.getProperty("user.home"),
+        windows: Boolean = isWindows()
+    ): String {
+        val nodeDir = nodeCommand?.let { File(it).parentFile }
+        val bootstrapDirs = if (!windows && home != null) listOf(
+            File(home, ".local/share/moe/node/current/bin"),
+            File(home, ".local/share/moe/npm/bin")
+        ).filter { it.isDirectory }.map { it.absolutePath } else emptyList()
+        return (listOfNotNull(nodeDir?.absolutePath) + current.split(File.pathSeparator) + bootstrapDirs)
+            .filter { it.isNotBlank() }.distinct().joinToString(File.pathSeparator)
+    }
+
+    internal fun resolveNodeExecutable(
+        environment: Map<String, String> = System.getenv(),
+        home: String? = System.getProperty("user.home"),
+        windows: Boolean = isWindows(),
+        nodeOnPath: () -> String? = { if (windows) findNodeFromWhere() else findNodeViaWhich() }
+    ): String? {
+        val env = environment["MOE_NODE_COMMAND"]?.trim()
         if (!env.isNullOrBlank()) {
             return env.trim('"')
         }
-        if (isWindows()) {
-            val programFiles = System.getenv("ProgramFiles")
-            val programFilesX86 = System.getenv("ProgramFiles(x86)")
-            val localAppData = System.getenv("LOCALAPPDATA")
-            val appData = System.getenv("APPDATA")
+        // The installer selects this runtime when the system Node is unsupported.
+        // GUI-launched IDEs do not load the shell profile that puts it on PATH.
+        if (!windows && home != null) {
+            val managed = File(home, ".local/share/moe/node/current/bin/node")
+            if (managed.isFile && managed.canExecute()) return managed.absolutePath
+        }
+        nodeOnPath()?.let { return it }
+        if (windows) {
+            val programFiles = environment["ProgramFiles"]
+            val programFilesX86 = environment["ProgramFiles(x86)"]
+            val localAppData = environment["LOCALAPPDATA"]
+            val appData = environment["APPDATA"]
             val candidates = listOfNotNull(
                 programFiles?.let { File(it, "nodejs\\node.exe") },
                 programFilesX86?.let { File(it, "nodejs\\node.exe") },
@@ -291,11 +314,10 @@ class MoeDaemonSupervisor(
             )
             val found = candidates.firstOrNull { it.exists() }?.absolutePath
             if (found != null) return found
-            return findNodeFromWhere()
+            return null
         }
         // macOS / Linux: check common node locations since ProcessBuilder
         // does not inherit the user's shell PATH when launched from the IDE
-        val home = System.getProperty("user.home")
         val macLinuxCandidates = listOfNotNull(
             File("/opt/homebrew/bin/node"),         // Homebrew ARM (Apple Silicon)
             File("/usr/local/bin/node"),             // Homebrew Intel / system
@@ -312,7 +334,7 @@ class MoeDaemonSupervisor(
             log.debug("Resolved node on macOS/Linux: $found")
             return found
         }
-        return findNodeViaWhich()
+        return null
     }
 
     private fun findNodeFromWhere(): String? {
@@ -329,7 +351,7 @@ class MoeDaemonSupervisor(
             val reader = BufferedReader(InputStreamReader(process.inputStream))
             val line = reader.readLine()?.trim()
             reader.close()
-            if (!line.isNullOrBlank()) line else null
+            if (process.exitValue() == 0 && !line.isNullOrBlank() && File(line).isFile) line else null
         } catch (ex: Exception) {
             log.debug("Failed to find node via 'where' command", ex)
             null
@@ -352,7 +374,7 @@ class MoeDaemonSupervisor(
             val reader = BufferedReader(InputStreamReader(process.inputStream))
             val line = reader.readLine()?.trim()
             reader.close()
-            if (!line.isNullOrBlank()) line else null
+            if (process.exitValue() == 0 && !line.isNullOrBlank() && File(line).isFile) line else null
         } catch (ex: Exception) {
             log.debug("Failed to find node via 'which' command", ex)
             null

--- a/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/CreateTaskDialog.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/toolwindow/CreateTaskDialog.kt
@@ -35,6 +35,17 @@ class CreateTaskDialog(
     private val service: MoeProjectService
 ) : DialogWrapper(ideaProject), Disposable {
 
+    companion object {
+        internal fun <T> epicSelectionModel(epics: List<T>, createNew: T): DefaultComboBoxModel<T> =
+            DefaultComboBoxModel<T>().apply {
+                epics.forEach { addElement(it) }
+                addElement(createNew)
+                // An action preselected as the sole option emits no SELECTED event
+                // when clicked, so a fresh project could never create its first epic.
+                if (epics.isEmpty()) selectedItem = null
+            }
+    }
+
     private val epicCombo = ComboBox<EpicOption>()
     private val priorityCombo = ComboBox(arrayOf("CRITICAL", "HIGH", "MEDIUM", "LOW"))
     private val titleField = JBTextField()
@@ -102,9 +113,7 @@ class CreateTaskDialog(
                         ?: (epicCombo.model as? DefaultComboBoxModel<EpicOption>)?.let { model ->
                             if (model.size > 1) model.getElementAt(0) else null
                         }
-                    if (revertTo != null) {
-                        epicCombo.selectedItem = revertTo
-                    }
+                    epicCombo.selectedItem = revertTo
 
                     // Show create epic dialog
                     val dialog = CreateEpicDialog(ideaProject, service)
@@ -114,6 +123,7 @@ class CreateTaskDialog(
                 } else if (selected?.epic != null) {
                     lastSelectedEpic = selected.epic
                 }
+                validateFields()
             }
         }
         epicCombo.addItemListener(epicComboListener)
@@ -156,8 +166,8 @@ class CreateTaskDialog(
     }
 
     private fun refreshEpicCombo(selectEpic: Epic?) {
-        val items = epics.map { EpicOption(it) } + EpicOption.createNew()
-        epicCombo.model = DefaultComboBoxModel(items.toTypedArray())
+        val items = epics.map { EpicOption(it) }
+        epicCombo.model = epicSelectionModel(items, EpicOption.createNew())
         if (selectEpic != null) {
             val option = items.find { it.epic?.id == selectEpic.id }
             if (option != null) {
@@ -172,6 +182,7 @@ class CreateTaskDialog(
         } else if (epics.isNotEmpty()) {
             lastSelectedEpic = epics.first()
         }
+        validateFields()
     }
 
     private fun validateFields(): Boolean {
@@ -263,7 +274,7 @@ class CreateTaskDialog(
             isSelected: Boolean,
             cellHasFocus: Boolean
         ): java.awt.Component {
-            label.text = value?.displayText ?: ""
+            label.text = value?.displayText ?: MoeBundle.message("moe.message.selectOrCreateEpic")
             if (value?.isCreateNew == true) {
                 label.font = label.font.deriveFont(java.awt.Font.ITALIC)
             } else {

--- a/moe-jetbrains/src/main/resources/messages/MoeBundle.properties
+++ b/moe-jetbrains/src/main/resources/messages/MoeBundle.properties
@@ -96,6 +96,7 @@ moe.message.noPendingProposals=No pending proposals
 moe.message.noCriteriaDefined=No criteria defined
 moe.message.noPlanDefined=No implementation plan defined
 moe.message.createNewEpic=Create New Epic...
+moe.message.selectOrCreateEpic=Select or create an epic
 moe.message.noEpic=No Epic
 moe.message.rejectedInUI=Rejected in UI
 moe.message.reopenedInUI=Reopened in UI

--- a/moe-jetbrains/src/test/kotlin/com/moe/services/MoeDaemonSupervisorTest.kt
+++ b/moe-jetbrains/src/test/kotlin/com/moe/services/MoeDaemonSupervisorTest.kt
@@ -150,6 +150,60 @@ class MoeDaemonSupervisorTest {
     private fun initializedRoot(name: String): File =
         temporaryFolder.newFolder(name).also { File(it, ".moe").mkdirs() }
 
+    @Test
+    fun `GUI without PATH Node discovers the bootstrapped runtime`() {
+        val home = temporaryFolder.newFolder("gui-home")
+        val node = File(home, ".local/share/moe/node/current/bin/node").apply {
+            parentFile.mkdirs()
+            writeText("fixture")
+            setExecutable(true)
+        }
+
+        assertEquals(node.absolutePath, supervisor(home).resolveNodeExecutable(emptyMap(), home.absolutePath, false) { null })
+    }
+
+    @Test
+    fun `Node override wins and existing PATH is used when no managed runtime exists`() {
+        val home = temporaryFolder.newFolder("node-priority")
+        val managed = File(home, ".local/share/moe/node/current/bin/node").apply {
+            parentFile.mkdirs()
+            writeText("fixture")
+            setExecutable(true)
+        }
+        val service = supervisor(home)
+
+        assertEquals("requested-node", service.resolveNodeExecutable(mapOf("MOE_NODE_COMMAND" to "requested-node"), home.absolutePath, false) { "path-node" })
+        assertTrue(managed.delete())
+        assertEquals("path-node", service.resolveNodeExecutable(emptyMap(), home.absolutePath, false) { "path-node" })
+    }
+
+    @Test
+    fun `managed Node replaces an old system runtime for GUI launches`() {
+        val home = temporaryFolder.newFolder("old-system-node")
+        val managed = File(home, ".local/share/moe/node/current/bin/node").apply {
+            parentFile.mkdirs()
+            writeText("fixture")
+            setExecutable(true)
+        }
+        val service = supervisor(home)
+        val chosen = service.resolveNodeExecutable(emptyMap(), home.absolutePath, false) { "/usr/bin/node" }
+
+        assertEquals(managed.absolutePath, chosen)
+        assertEquals(managed.parentFile.absolutePath, service.daemonPath("/usr/bin", chosen, home.absolutePath, false).split(File.pathSeparator).first())
+    }
+
+    @Test
+    fun `daemon children discover bootstrap Node and agent bins without replacing PATH`() {
+        val home = temporaryFolder.newFolder("child-path")
+        val nodeBin = File(home, ".local/share/moe/node/current/bin").apply { mkdirs() }
+        val agentBin = File(home, ".local/share/moe/npm/bin").apply { mkdirs() }
+        val current = listOf("existing-first", "existing-second").joinToString(File.pathSeparator)
+
+        val path = supervisor(home).daemonPath(current, null, home.absolutePath, false)
+
+        assertEquals(listOf("existing-first", "existing-second", nodeBin.absolutePath, agentBin.absolutePath), path.split(File.pathSeparator))
+    }
+
     private fun supervisor(
         root: File,
         onStatus: (Boolean, String) -> Unit = { _, _ -> },

--- a/moe-jetbrains/src/test/kotlin/com/moe/toolwindow/CreateTaskDialogTest.kt
+++ b/moe-jetbrains/src/test/kotlin/com/moe/toolwindow/CreateTaskDialogTest.kt
@@ -1,0 +1,42 @@
+package com.moe.toolwindow
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.awt.event.ItemEvent
+import javax.swing.JComboBox
+
+class CreateTaskDialogTest {
+    @Test
+    fun `fresh project can select create epic after the listener is installed`() {
+        val createNew = "Create New Epic..."
+        val combo = JComboBox(CreateTaskDialog.epicSelectionModel(emptyList(), createNew))
+        var createRequests = 0
+        combo.addItemListener { event ->
+            if (event.stateChange == ItemEvent.SELECTED && event.item == createNew) {
+                createRequests++
+            }
+        }
+
+        combo.selectedItem = createNew
+
+        assertEquals("Selecting the only option must open epic creation", 1, createRequests)
+    }
+
+    @Test
+    fun `fresh project has no selected epic`() {
+        val model = CreateTaskDialog.epicSelectionModel(emptyList(), "Create New Epic...")
+
+        assertNull(model.selectedItem)
+        assertEquals(1, model.size)
+    }
+
+    @Test
+    fun `existing project keeps its first epic selected`() {
+        val model = CreateTaskDialog.epicSelectionModel(listOf("First epic", "Second epic"), "Create New Epic...")
+
+        assertEquals("First epic", model.selectedItem)
+        assertEquals(3, model.size)
+        assertEquals("Create New Epic...", model.getElementAt(2))
+    }
+}

--- a/moe-vscode/package.json
+++ b/moe-vscode/package.json
@@ -188,6 +188,7 @@
   "scripts": {
     "vscode:prepublish": "npm run bundle && npm run esbuild",
     "compile": "tsc -p ./",
+    "test": "node --test tests/*.test.cjs",
     "watch": "tsc -watch -p ./",
     "esbuild": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "esbuild:watch": "npm run esbuild -- --watch",

--- a/moe-vscode/src/services/MoeDaemonClient.ts
+++ b/moe-vscode/src/services/MoeDaemonClient.ts
@@ -625,6 +625,37 @@ export class MoeDaemonClient implements vscode.Disposable {
         }
     }
 
+    private resolveDaemonRuntime(): { node: string; env: NodeJS.ProcessEnv } {
+        const env = { ...process.env };
+        const override = env.MOE_NODE_COMMAND;
+        const home = env.HOME || env.USERPROFILE;
+        if (process.platform === 'win32' || !home) { return { node: override || 'node', env }; }
+
+        const originalPath = env.PATH ?? '/usr/bin:/bin';
+        const entries = originalPath.split(path.delimiter);
+        const nodeDir = path.join(home, '.local', 'share', 'moe', 'node', 'current', 'bin');
+        const npmDir = path.join(home, '.local', 'share', 'moe', 'npm', 'bin');
+        for (const directory of [nodeDir, npmDir]) {
+            if (!entries.includes(directory) && fs.existsSync(directory)) { entries.push(directory); }
+        }
+        env.PATH = entries.join(path.delimiter);
+
+        const isExecutable = (candidate: string): boolean => {
+            try {
+                fs.accessSync(candidate, fs.constants.X_OK);
+                return fs.statSync(candidate).isFile();
+            } catch { return false; }
+        };
+        // Match the installer's env.sh: its managed Node replaces missing or obsolete system Node.
+        const installedNode = path.join(nodeDir, 'node');
+        const useInstalledNode = !override && isExecutable(installedNode);
+        if (useInstalledNode) {
+            env.PATH = [nodeDir, ...entries.filter(directory => directory !== nodeDir)].join(path.delimiter);
+        }
+        const node = override || (useInstalledNode ? installedNode : 'node');
+        return { node, env };
+    }
+
     private async startDaemon(command: 'init' | 'start', projectPath: string): Promise<void> {
         if (this.startInProgress) {
             return;
@@ -637,21 +668,35 @@ export class MoeDaemonClient implements vscode.Disposable {
 
         this.startInProgress = true;
         try {
-            const node = process.env.MOE_NODE_COMMAND || 'node';
+            const { node, env } = this.resolveDaemonRuntime();
             const args = [daemonPath, command, '--project', projectPath];
             if (command === 'init') {
                 args.push('--name', path.basename(projectPath));
             }
-            const proc = spawn(node, args, {
-                detached: true,
-                stdio: 'ignore',
-                windowsHide: true
+            await new Promise<void>((resolve, reject) => {
+                const proc = spawn(node, args, {
+                    detached: true,
+                    stdio: 'ignore',
+                    windowsHide: true,
+                    env
+                });
+                // Missing executables fail asynchronously; try/catch around spawn
+                // alone leaves ENOENT as an unhandled child-process error.
+                proc.once('error', reject);
+                proc.once('spawn', () => {
+                    proc.unref();
+                    resolve();
+                });
             });
-            proc.unref();
             log(`Started Moe daemon (${command}) for ${projectPath}`);
             await this.waitForDaemonInfo(projectPath, 10000);
         } catch (err) {
-            log(`Failed to start daemon: ${err instanceof Error ? err.message : String(err)}`);
+            const detail = err instanceof Error ? err.message : String(err);
+            log(`Failed to start daemon: ${detail}`);
+            const message = (err as NodeJS.ErrnoException)?.code === 'ENOENT'
+                ? 'Moe could not start Node.js. Run the Moe installer and restart VS Code, or set MOE_NODE_COMMAND to its executable path.'
+                : `Moe could not start its daemon: ${detail}`;
+            vscode.window.showErrorMessage(message);
         } finally {
             this.startInProgress = false;
         }

--- a/moe-vscode/tests/daemon-start.test.cjs
+++ b/moe-vscode/tests/daemon-start.test.cjs
@@ -1,0 +1,157 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { test } = require('node:test');
+const ts = require('typescript');
+
+const sourcePath = path.join(__dirname, '../src/services/MoeDaemonClient.ts');
+const compiled = ts.transpileModule(fs.readFileSync(sourcePath, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020, esModuleInterop: true }
+}).outputText;
+
+function fixture({ env, platform, files = [], directories = [] } = {}) {
+    const child = new EventEmitter();
+    let unrefs = 0;
+    child.unref = () => { unrefs++; };
+    const logs = [];
+    const errors = [];
+    const spawns = [];
+    const fakeFiles = new Set(files);
+    const fakeDirectories = new Set(directories);
+    const simulatedFs = env ? {
+        ...fs,
+        existsSync: file => fakeFiles.has(file) || fakeDirectories.has(file),
+        statSync: file => {
+            if (!fakeFiles.has(file) && !fakeDirectories.has(file)) { throw new Error('ENOENT'); }
+            return { isFile: () => fakeFiles.has(file), isDirectory: () => fakeDirectories.has(file) };
+        },
+        accessSync: file => { if (!fakeFiles.has(file)) { throw new Error('EACCES'); } }
+    } : fs;
+    const module = { exports: {} };
+    const vscode = {
+        EventEmitter: class { event = () => ({ dispose() {} }); },
+        window: {
+            createOutputChannel: () => ({ appendLine: line => logs.push(line) }),
+            showErrorMessage: message => { errors.push(message); return Promise.resolve(undefined); }
+        }
+    };
+    const context = vm.createContext({
+        exports: module.exports, module, process: env ? { ...process, env, platform } : process,
+        console, setTimeout, clearTimeout, setInterval, clearInterval,
+        require: name => name === 'vscode' ? vscode
+            : name === 'child_process' ? { spawn: (...args) => { spawns.push(args); return child; } }
+            : name === 'fs' ? simulatedFs
+            : name === 'path' && platform === 'linux' ? path.posix
+            : require(name)
+    });
+    vm.runInContext(compiled, context, { filename: sourcePath });
+    const client = new module.exports.MoeDaemonClient('plugin');
+    client.resolveBundledDaemonPath = () => 'bundled-daemon.js';
+    let polls = 0;
+    client.waitForDaemonInfo = async () => { polls++; };
+    return { client, child, logs, errors, spawns, polls: () => polls, unrefs: () => unrefs };
+}
+
+test('missing Node reports an actionable error without escaping the startup handler', async () => {
+    const f = fixture();
+    const startup = f.client.startDaemon('start', 'project');
+    const failure = Object.assign(new Error('spawn node ENOENT'), { code: 'ENOENT' });
+    let escaped;
+    try { f.child.emit('error', failure); } catch (error) { escaped = error; }
+    await startup;
+
+    assert.equal(escaped, undefined, 'the child-process error must be handled');
+    assert.equal(f.polls(), 0, 'a failed launch must not wait for daemon readiness');
+    assert.equal(f.errors.length, 1);
+    assert.match(f.errors[0], /Node\.js/);
+    assert.match(f.errors[0], /MOE_NODE_COMMAND/);
+    assert.equal(f.logs.some(line => line.includes('Started Moe daemon')), false);
+});
+
+test('other spawn failures are surfaced without claiming the daemon started', async () => {
+    const f = fixture();
+    const startup = f.client.startDaemon('start', 'project');
+    const failure = Object.assign(new Error('spawn node EACCES'), { code: 'EACCES' });
+    let escaped;
+    try { f.child.emit('error', failure); } catch (error) { escaped = error; }
+    await startup;
+
+    assert.equal(escaped, undefined);
+    assert.equal(f.polls(), 0);
+    assert.equal(f.errors.length, 1);
+    assert.match(f.errors[0], /EACCES/);
+    assert.equal(f.logs.some(line => line.includes('Started Moe daemon')), false);
+});
+
+test('successful spawn waits for daemon readiness and detaches the process', async () => {
+    const f = fixture();
+    const startup = f.client.startDaemon('start', 'project');
+    f.child.emit('spawn');
+    await startup;
+
+    assert.equal(f.polls(), 1);
+    assert.equal(f.unrefs(), 1);
+    assert.deepEqual(f.errors, []);
+    assert.equal(f.logs.filter(line => line.includes('Started Moe daemon')).length, 1);
+});
+
+test('Linux GUI launch finds installer Node and passes helper command directories to the daemon', async () => {
+    const nodeDir = '/home/dev/.local/share/moe/node/current/bin';
+    const npmDir = '/home/dev/.local/share/moe/npm/bin';
+    const f = fixture({
+        env: { HOME: '/home/dev', PATH: '/usr/bin:/bin' }, platform: 'linux',
+        files: [`${nodeDir}/node`], directories: [nodeDir, npmDir]
+    });
+    const startup = f.client.startDaemon('start', 'project');
+    f.child.emit('spawn');
+    await startup;
+
+    assert.equal(f.spawns[0][0], `${nodeDir}/node`);
+    assert.equal(f.spawns[0][2].env.PATH, `${nodeDir}:/usr/bin:/bin:${npmDir}`);
+});
+
+test('managed Node takes priority over an obsolete system Node in the GUI PATH', async () => {
+    const nodeDir = '/home/dev/.local/share/moe/node/current/bin';
+    const npmDir = '/home/dev/.local/share/moe/npm/bin';
+    const f = fixture({
+        env: { HOME: '/home/dev', PATH: '/old/system/bin:/usr/bin' }, platform: 'linux',
+        files: ['/old/system/bin/node', `${nodeDir}/node`], directories: [nodeDir, npmDir]
+    });
+    const startup = f.client.startDaemon('start', 'project');
+    f.child.emit('spawn');
+    await startup;
+
+    assert.equal(f.spawns[0][0], `${nodeDir}/node`);
+    assert.equal(f.spawns[0][2].env?.PATH, `${nodeDir}:/old/system/bin:/usr/bin:${npmDir}`);
+});
+
+test('PATH-selected Node is preserved when no helper-managed Node is installed', async () => {
+    const npmDir = '/home/dev/.local/share/moe/npm/bin';
+    const f = fixture({
+        env: { HOME: '/home/dev', PATH: '/my/node/bin:/usr/bin' }, platform: 'linux',
+        files: ['/my/node/bin/node'], directories: [npmDir]
+    });
+    const startup = f.client.startDaemon('start', 'project');
+    f.child.emit('spawn');
+    await startup;
+
+    assert.equal(f.spawns[0][0], 'node');
+    assert.equal(f.spawns[0][2].env?.PATH, `/my/node/bin:/usr/bin:${npmDir}`);
+});
+
+test('explicit Node override is preserved and helper PATH entries are not duplicated', async () => {
+    const nodeDir = '/home/dev/.local/share/moe/node/current/bin';
+    const npmDir = '/home/dev/.local/share/moe/npm/bin';
+    const originalPath = `/usr/bin:${nodeDir}:${npmDir}`;
+    const env = { HOME: '/home/dev', PATH: originalPath, MOE_NODE_COMMAND: '/custom/node' };
+    const f = fixture({ env, platform: 'linux', files: [`${nodeDir}/node`], directories: [nodeDir, npmDir] });
+    const startup = f.client.startDaemon('start', 'project');
+    f.child.emit('spawn');
+    await startup;
+
+    assert.equal(f.spawns[0][0], '/custom/node');
+    assert.equal(f.spawns[0][2].env?.PATH, originalPath);
+    assert.equal(env.PATH, originalPath, 'VS Code host environment must remain unchanged');
+});

--- a/packages/moe-daemon/package-lock.json
+++ b/packages/moe-daemon/package-lock.json
@@ -2015,9 +2015,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2354,9 +2354,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2639,9 +2639,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/moe-daemon/src/index.ts
+++ b/packages/moe-daemon/src/index.ts
@@ -10,7 +10,7 @@ import net from 'net';
 import http from 'http';
 import crypto from 'crypto';
 import { spawn, type ChildProcess } from 'child_process';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { StateManager } from './state/StateManager.js';
 import { FileWatcher } from './state/FileWatcher.js';
 import { McpAdapter } from './server/McpAdapter.js';
@@ -18,13 +18,12 @@ import { MoeWebSocketServer } from './server/WebSocketServer.js';
 import { backfillTaskMetrics } from './state/backfills/backfillTaskMetrics.js';
 import { runDoctor } from './commands/doctor.js';
 import { logger } from './util/logger.js';
+import { VERSION } from './util/version.js';
 import { writeInitFiles } from './generated/initFiles.js';
 import { writeSkillFiles } from './generated/skillFiles.js';
 import { clearAllSpeedModeTimeouts, rearmSpeedModeApprovals } from './tools/submitPlan.js';
 import os from 'os';
 import type { DaemonInfo } from './types/schema.js';
-
-const VERSION = '0.1.0';
 
 // Configurable via environment variables with sensible defaults
 const DEFAULT_PORT = parseInt(process.env.MOE_DEFAULT_PORT || '9876', 10);
@@ -426,8 +425,8 @@ function consumeStopSentinel(projectPath: string): boolean {
 
 function writeGlobalConfig(): void {
   try {
-    // Derive installPath: __dirname is packages/moe-daemon/dist, go up 3 levels
-    const installPath = path.resolve(__dirname, '..', '..', '..');
+    // Source and compiled entrypoints sit three levels below the checkout root.
+    const installPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
     const canary = path.join(installPath, 'packages', 'moe-daemon', 'dist', 'index.js');
     if (!fs.existsSync(canary)) {
       // Not running from source tree (e.g. npm global install) — skip

--- a/packages/moe-daemon/src/server/McpAdapter.test.ts
+++ b/packages/moe-daemon/src/server/McpAdapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { McpAdapter, RateLimiter, type JsonRpcRequest, type JsonRpcResponse } from './McpAdapter.js';
 import type { StateManager } from '../state/StateManager.js';
 import { invalidInput, invalidState, notAllowed, notFound } from '../util/errors.js';
@@ -90,6 +91,15 @@ describe('McpAdapter', () => {
       }),
     });
   }
+
+  it('reports the installed package version during the initialize handshake', async () => {
+    const manifest = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+    const response = await adapter.handle({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+    expect(response).toMatchObject({
+      result: { serverInfo: { name: 'moe-daemon', version: manifest.version } },
+    });
+  });
 
   describe('tools/list', () => {
     it('returns list of available tools', async () => {

--- a/packages/moe-daemon/src/server/McpAdapter.ts
+++ b/packages/moe-daemon/src/server/McpAdapter.ts
@@ -5,6 +5,7 @@
 import type { StateManager } from '../state/StateManager.js';
 import { getTools } from '../tools/index.js';
 import { logger } from '../util/logger.js';
+import { VERSION } from '../util/version.js';
 import { MoeError } from '../util/errors.js';
 
 // Rate limiter configuration (configurable via environment variables)
@@ -245,7 +246,7 @@ export class McpAdapter {
           result: {
             protocolVersion: '2024-11-05',
             capabilities: { tools: {} },
-            serverInfo: { name: 'moe-daemon', version: '0.1.0' }
+            serverInfo: { name: 'moe-daemon', version: VERSION }
           }
         };
       }

--- a/packages/moe-daemon/src/server/WebSocketServer.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.ts
@@ -325,14 +325,15 @@ export class MoeWebSocketServer {
               const existing = this.state.getTask(taskId);
               if (existing) {
                 // Keep in sync with VALID_TRANSITIONS in src/tools/setTaskStatus.ts.
-                // ARCHIVED is reachable from resting statuses (BACKLOG / REVIEW / DONE).
+                // ARCHIVED is reachable from resting statuses (BACKLOG / REVIEW / DONE)
+                // and, as a shelf for rows that need no work, from PLANNING and BLOCKED.
                 const VALID_TRANSITIONS: Record<string, string[]> = {
                   BACKLOG: ['PLANNING', 'WORKING', 'ARCHIVED'],
-                  PLANNING: ['AWAITING_APPROVAL', 'BACKLOG', 'BLOCKED'],
+                  PLANNING: ['AWAITING_APPROVAL', 'BACKLOG', 'BLOCKED', 'ARCHIVED'],
                   AWAITING_APPROVAL: ['WORKING', 'PLANNING'],
                   WORKING: ['REVIEW', 'PLANNING', 'BACKLOG', 'BLOCKED'],
                   REVIEW: ['DONE', 'WORKING', 'BACKLOG', 'PLANNING', 'ARCHIVED', 'BLOCKED'],
-                  BLOCKED: ['WORKING', 'PLANNING', 'REVIEW', 'BACKLOG'],
+                  BLOCKED: ['WORKING', 'PLANNING', 'REVIEW', 'BACKLOG', 'ARCHIVED'],
                   DONE: ['BACKLOG', 'WORKING', 'ARCHIVED'],
                   ARCHIVED: ['BACKLOG', 'WORKING']
                 };
@@ -350,7 +351,7 @@ export class MoeWebSocketServer {
                   // src/tools/setTaskStatus.ts.
                   if (existing.status === 'BLOCKED') {
                     const effectiveFrom = existing.blockedFromStatus ?? 'WORKING';
-                    if (newStatus !== effectiveFrom
+                    if (newStatus !== effectiveFrom && newStatus !== 'ARCHIVED'
                       && !(VALID_TRANSITIONS[effectiveFrom] ?? []).includes(newStatus)) {
                       throw new Error(`Cannot move task from BLOCKED to ${newStatus}: it was blocked from ${effectiveFrom} and ${effectiveFrom} -> ${newStatus} is not legal. Un-block to ${effectiveFrom} first.`);
                     }

--- a/packages/moe-daemon/src/state/FileWatcher.paths.test.ts
+++ b/packages/moe-daemon/src/state/FileWatcher.paths.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import chokidar from 'chokidar';
+import { FileWatcher } from './FileWatcher.js';
+
+vi.mock('chokidar', () => ({ default: { watch: vi.fn() } }));
+
+describe('FileWatcher canonical paths', () => {
+  let scratch: string;
+  let aliasRoot: string;
+  let canonicalRoot: string;
+  let events: EventEmitter;
+  let watcher: FileWatcher;
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'moe watcher path '));
+    const project = path.join(scratch, 'actual project');
+    fs.mkdirSync(path.join(project, '.moe', 'tasks'), { recursive: true });
+    const alias = path.join(scratch, 'alias project');
+    fs.symlinkSync(project, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    aliasRoot = path.join(alias, '.moe');
+    canonicalRoot = fs.realpathSync.native(aliasRoot);
+    events = new EventEmitter();
+    vi.mocked(chokidar.watch).mockReturnValue(Object.assign(events, {
+      close: vi.fn().mockResolvedValue(undefined)
+    }) as unknown as chokidar.FSWatcher);
+    onChange = vi.fn();
+    watcher = new FileWatcher(aliasRoot, onChange);
+  });
+
+  afterEach(async () => {
+    await watcher.stop();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it('passes the native canonical root to chokidar instead of an alias', () => {
+    const nativePath = vi.spyOn(fs.realpathSync, 'native');
+    watcher.start();
+
+    expect(nativePath).toHaveBeenCalledWith(path.resolve(aliasRoot));
+    const patterns = vi.mocked(chokidar.watch).mock.lastCall![0] as string[];
+    const root = canonicalRoot.split(path.sep).join('/');
+    expect(patterns).toContain(`${root}/project.json`);
+    expect(patterns).toContain(`${root}/tasks/*.json`);
+    expect(patterns.every(pattern => pattern.startsWith(`${root}/`))).toBe(true);
+  });
+
+  for (const type of ['add', 'change', 'unlink'] as const) {
+    it(`suppresses canonical ${type} events for a self-write through the original alias`, async () => {
+      const file = path.join(canonicalRoot, 'tasks', 'self-write.json');
+      fs.writeFileSync(file, '{}');
+      watcher.start();
+      watcher.ignorePath(path.join(aliasRoot, 'tasks', 'self-write.json'));
+      if (type === 'unlink') fs.unlinkSync(file);
+
+      events.emit(type, file);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  }
+
+  it('preserves suppression registered before start, including a file that does not exist', async () => {
+    watcher.ignorePath(path.join(aliasRoot, 'tasks', 'new.json'));
+    watcher.start();
+    events.emit('add', path.join(canonicalRoot, 'tasks', 'new.json'));
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('delivers external changes and consumes each suppression only once', async () => {
+    watcher.start();
+    const file = path.join(canonicalRoot, 'tasks', 'shared.json');
+    watcher.ignorePath(path.join(aliasRoot, 'tasks', 'shared.json'));
+    events.emit('change', file);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).not.toHaveBeenCalled();
+
+    events.emit('change', file);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ type: 'change', path: file });
+  });
+
+  it('does not suppress another directory with the same filename', async () => {
+    watcher.start();
+    watcher.ignorePath(path.join(`${aliasRoot}-other`, 'tasks', 'task.json'));
+    const file = path.join(canonicalRoot, 'tasks', 'task.json');
+    events.emit('change', file);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ type: 'change', path: file });
+  });
+});

--- a/packages/moe-daemon/src/state/FileWatcher.ts
+++ b/packages/moe-daemon/src/state/FileWatcher.ts
@@ -3,6 +3,7 @@
 // =============================================================================
 
 import chokidar from 'chokidar';
+import fs from 'fs';
 import path from 'path';
 import { logger } from '../util/logger.js';
 
@@ -19,17 +20,35 @@ export class FileWatcher {
   private stopped = false;
   private readonly debounceMs = 150;
   private ignorePaths = new Set<string>();
+  private canonicalMoePath: string | null = null;
 
   constructor(
     private readonly moePath: string,
     private readonly onChange: (event: FileChangeEvent) => void | Promise<void>
   ) {}
 
+  private watchRoot(): string {
+    // Windows 8.3 aliases can crash libuv's native watcher when a file arrives.
+    // Resolve the existing directory before chokidar opens any native handles.
+    return this.canonicalMoePath ??= fs.realpathSync.native(path.resolve(this.moePath));
+  }
+
+  private normalizeEventPath(filePath: string): string {
+    const normalized = path.resolve(filePath);
+    const relative = path.relative(path.resolve(this.moePath), normalized);
+    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      return normalized;
+    }
+    // State writes still use the caller's alias; chokidar emits canonical paths.
+    // Map by the root so new and deleted files need not exist for suppression.
+    return path.join(this.watchRoot(), relative);
+  }
+
   /**
    * Mark a file path to be ignored on the next change event (self-write suppression).
    */
   ignorePath(filePath: string): void {
-    const normalized = path.resolve(filePath);
+    const normalized = this.normalizeEventPath(filePath);
     this.ignorePaths.add(normalized);
     // Auto-expire after 500ms to prevent leaks
     const t = setTimeout(() => this.ignorePaths.delete(normalized), 500);
@@ -39,15 +58,16 @@ export class FileWatcher {
   start(): void {
     if (this.watcher) return;
 
+    const root = this.watchRoot().split(path.sep).join('/');
     const patterns = [
-      `${this.moePath}/project.json`,
-      `${this.moePath}/epics/*.json`,
-      `${this.moePath}/tasks/*.json`,
-      `${this.moePath}/workers/*.json`,
-      `${this.moePath}/proposals/*.json`,
-      `${this.moePath}/channels/*.json`,
-      `${this.moePath}/pins/*.json`,
-      `${this.moePath}/decisions/*.json`
+      `${root}/project.json`,
+      `${root}/epics/*.json`,
+      `${root}/tasks/*.json`,
+      `${root}/workers/*.json`,
+      `${root}/proposals/*.json`,
+      `${root}/channels/*.json`,
+      `${root}/pins/*.json`,
+      `${root}/decisions/*.json`
     ];
 
     this.watcher = chokidar.watch(patterns, {
@@ -74,7 +94,7 @@ export class FileWatcher {
   private scheduleChange(event: FileChangeEvent): void {
     if (this.stopped) return;
 
-    const normalized = path.resolve(event.path);
+    const normalized = this.normalizeEventPath(event.path);
     if (this.ignorePaths.has(normalized)) {
       this.ignorePaths.delete(normalized);
       return; // Skip self-writes

--- a/packages/moe-daemon/src/tools/archiveTask.test.ts
+++ b/packages/moe-daemon/src/tools/archiveTask.test.ts
@@ -49,5 +49,33 @@ describe('moe.archive_task', () => {
     const tool = archiveTaskTool(h.state);
     await expect(tool.handler({ taskId: 'nope' }, h.state)).rejects.toThrow();
   });
+
+  it('archives a PLANNING ticket held by the calling architect (nothing left to plan)', async () => {
+    h.createTask({ id: 'task-pl', status: 'PLANNING', assignedWorkerId: 'architect-1' });
+    await h.state.load();
+    const tool = archiveTaskTool(h.state);
+    const result = await tool.handler({ taskId: 'task-pl', workerId: 'architect-1' }, h.state) as { status: string };
+    expect(result.status).toBe('ARCHIVED');
+    expect(h.state.getTask('task-pl')!.assignedWorkerId).toBeNull();
+  });
+
+  it('refuses to archive a PLANNING ticket held by another worker', async () => {
+    h.createTask({ id: 'task-pl2', status: 'PLANNING', assignedWorkerId: 'architect-1' });
+    await h.state.load();
+    const tool = archiveTaskTool(h.state);
+    await expect(tool.handler({ taskId: 'task-pl2', workerId: 'architect-2' }, h.state)).rejects.toThrow('held by architect-1');
+  });
+
+  it('archives an unassigned BLOCKED ticket and clears its block bookkeeping', async () => {
+    h.createTask({ id: 'task-bk', status: 'BLOCKED', blockedFromStatus: 'WORKING', blockedAt: '2026-09-05T22:22:00.000Z', blockedReason: 'needs PostgreSQL' });
+    await h.state.load();
+    const tool = archiveTaskTool(h.state);
+    const result = await tool.handler({ taskId: 'task-bk' }, h.state) as { status: string };
+    expect(result.status).toBe('ARCHIVED');
+    const task = h.state.getTask('task-bk')!;
+    expect(task.blockedFromStatus).toBeNull();
+    expect(task.blockedReason).toBeNull();
+    expect(task.priorBlockedReason).toBe('needs PostgreSQL');
+  });
 });
 

--- a/packages/moe-daemon/src/tools/archiveTask.ts
+++ b/packages/moe-daemon/src/tools/archiveTask.ts
@@ -1,31 +1,38 @@
 import type { ToolDefinition } from './index.js';
 import type { StateManager } from '../state/StateManager.js';
-import type { TaskStatus } from '../types/schema.js';
+import type { Task, TaskStatus } from '../types/schema.js';
 import { missingRequired, notFound, notAllowed } from '../util/errors.js';
 
 /**
- * Resting statuses from which a ticket can be shelved. In-flight states
- * (PLANNING / AWAITING_APPROVAL / WORKING) are deliberately excluded — a worker
- * may own the task; move it to BACKLOG first (set_task_status — release_task
- * keeps a WORKING task in the WORKING column, so releasing is not enough).
+ * Statuses from which a ticket can be shelved. Resting statuses always; the
+ * two "nothing left to do" in-flight shapes too: PLANNING (the planner found
+ * the DoD already met, measured 2026-09-06 when an architect had to BLOCK such
+ * a row and page a governor) and BLOCKED (a dead park nobody will revive).
+ * A held PLANNING/BLOCKED row may only be archived by its holder or by a caller
+ * with no worker identity (a human). AWAITING_APPROVAL / WORKING stay excluded
+ * — a worker may own the task; move it to BACKLOG first (set_task_status —
+ * release_task keeps a WORKING task in the WORKING column, so releasing is not
+ * enough).
  */
-export const ARCHIVABLE_FROM: TaskStatus[] = ['BACKLOG', 'REVIEW', 'DONE'];
+export const ARCHIVABLE_FROM: TaskStatus[] = ['BACKLOG', 'REVIEW', 'DONE', 'PLANNING', 'BLOCKED'];
+const HOLDER_ONLY_FROM: TaskStatus[] = ['PLANNING', 'BLOCKED'];
 
 export function archiveTaskTool(_state: StateManager): ToolDefinition {
   return {
     name: 'moe.archive_task',
     description:
-      'Archive a ticket so it drops out of agent context — list_tasks/search_tasks hide ARCHIVED by default. Allowed from BACKLOG, REVIEW, or DONE (not in-flight states). Idempotent. Un-archive with set_task_status ARCHIVED→BACKLOG.',
+      'Archive a ticket so it drops out of agent context — list_tasks/search_tasks hide ARCHIVED by default. Allowed from BACKLOG, REVIEW, DONE, and from PLANNING or BLOCKED when nothing is left to do (a held PLANNING/BLOCKED row only by its holder). Not from AWAITING_APPROVAL/WORKING. Idempotent. Un-archive with set_task_status ARCHIVED→BACKLOG.',
     inputSchema: {
       type: 'object',
       properties: {
-        taskId: { type: 'string', description: 'The ID of the task to archive' }
+        taskId: { type: 'string', description: 'The ID of the task to archive' },
+        workerId: { type: 'string', description: 'Caller worker ID (auto-injected by proxy); a held PLANNING/BLOCKED row may only be archived by its holder' }
       },
       required: ['taskId'],
       additionalProperties: false
     },
     handler: async (args, state) => {
-      const params = (args || {}) as { taskId?: string };
+      const params = (args || {}) as { taskId?: string; workerId?: string };
       if (!params.taskId) {
         throw missingRequired('taskId');
       }
@@ -46,8 +53,26 @@ export function archiveTaskTool(_state: StateManager): ToolDefinition {
           `Task is ${task.status} (in-flight). Archive is only allowed from ${ARCHIVABLE_FROM.join(', ')}. Move it to BACKLOG first via moe.set_task_status (release_task keeps a WORKING task in the WORKING column).`
         );
       }
+      if (HOLDER_ONLY_FROM.includes(task.status) && task.assignedWorkerId
+        && params.workerId && params.workerId !== task.assignedWorkerId) {
+        throw notAllowed(
+          'archive task',
+          `Task is ${task.status} and held by ${task.assignedWorkerId}; only that worker (or a human / governor via set_task_status) may archive it.`
+        );
+      }
 
-      const updated = await state.updateTask(task.id, { status: 'ARCHIVED' }, 'TASK_ARCHIVED');
+      const updates: Partial<Task> = { status: 'ARCHIVED' };
+      if (task.status === 'BLOCKED') {
+        // Same clear-on-exit as set_task_status: only the operational block
+        // fields can be acted on by a later grant/sweep; the prose is kept.
+        if (task.blockedReason) updates.priorBlockedReason = task.blockedReason;
+        updates.blockedReason = null;
+        updates.blockedResourceId = null;
+        updates.blockedOnTaskIds = null;
+        updates.blockedFromStatus = null;
+        updates.blockedAt = null;
+      }
+      const updated = await state.updateTask(task.id, updates, 'TASK_ARCHIVED');
       return { success: true, taskId: updated.id, status: updated.status };
     }
   };

--- a/packages/moe-daemon/src/tools/chatBudgets.test.ts
+++ b/packages/moe-daemon/src/tools/chatBudgets.test.ts
@@ -196,25 +196,28 @@ describe('chat token budgets', () => {
     // even though it's actively blocked in a moe call — unlike wait_for_task,
     // which touches on entry. Bring chat_wait to parity.
     const channel = await setupChat();
-    const before = h.state.getWorker('worker-chat')!.lastActivityAt;
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    const before = new Date(Date.now() - 1000).toISOString();
+    await h.state.updateWorker('worker-chat', { lastActivityAt: before });
 
     const tool = chatWaitTool(h.state);
     const waitPromise = tool.handler({
       workerId: 'worker-chat',
       channels: [channel],
-      timeoutMs: 1000,
+      timeoutMs: 30000,
     }, h.state) as Promise<{ hasMessage: boolean }>;
 
     // The heartbeat touch is fire-and-forget (must not delay subscribing —
-    // see the comment in chatWait.ts), so give it a tick to land before
-    // asserting, independent of the wake/timeout timing below.
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(new Date(h.state.getWorker('worker-chat')!.lastActivityAt).getTime())
-      .toBeGreaterThan(new Date(before).getTime());
-
-    await h.state.sendMessage({ channel, sender: 'system', content: 'wake up' });
-    await waitPromise;
+    // see chatWait.ts). Wait for persistence instead of racing a fixed sleep.
+    // Observe entry well before the timeout heartbeat could mask a regression.
+    try {
+      await vi.waitFor(() => {
+        expect(new Date(h.state.getWorker('worker-chat')!.lastActivityAt).getTime())
+          .toBeGreaterThan(new Date(before).getTime());
+      }, { timeout: 2000, interval: 10 });
+    } finally {
+      await h.state.sendMessage({ channel, sender: 'system', content: 'wake up' });
+      await waitPromise;
+    }
   });
 
   it('rejects chat_send posting as the reserved "system" sender', async () => {

--- a/packages/moe-daemon/src/tools/setTaskStatus.test.ts
+++ b/packages/moe-daemon/src/tools/setTaskStatus.test.ts
@@ -33,6 +33,28 @@ describe('moe.set_task_status', () => {
     ).rejects.toThrow('status transition not allowed');
   });
 
+  it('PLANNING → ARCHIVED shelves a row that turned out to need no plan', async () => {
+    await h.state.updateTask('task-1', { status: 'PLANNING', assignedWorkerId: 'architect-1' });
+    const tool = setTaskStatusTool(h.state);
+    const result = await tool.handler({ taskId: 'task-1', status: 'ARCHIVED', reason: 'DoD met by a sibling' }, h.state) as { status: string };
+    expect(result.status).toBe('ARCHIVED');
+    expect(h.state.getTask('task-1')!.assignedWorkerId).toBeNull();
+  });
+
+  it('BLOCKED (from WORKING) → ARCHIVED shelves a dead park and clears its block bookkeeping', async () => {
+    await h.state.updateTask('task-1', { status: 'WORKING', assignedWorkerId: 'worker-1' });
+    const tool = setTaskStatusTool(h.state);
+    await tool.handler({ taskId: 'task-1', status: 'BLOCKED', reason: 'needs PostgreSQL' }, h.state);
+    const result = await tool.handler({ taskId: 'task-1', status: 'ARCHIVED' }, h.state) as { status: string };
+    expect(result.status).toBe('ARCHIVED');
+    const task = h.state.getTask('task-1')!;
+    expect(task.blockedFromStatus).toBeNull();
+    expect(task.blockedAt).toBeNull();
+    expect(task.blockedReason).toBeNull();
+    expect(task.priorBlockedReason).toBe('needs PostgreSQL');
+    expect(task.assignedWorkerId).toBeNull();
+  });
+
   it('rejects invalid status values', async () => {
     const tool = setTaskStatusTool(h.state);
     await expect(

--- a/packages/moe-daemon/src/tools/setTaskStatus.ts
+++ b/packages/moe-daemon/src/tools/setTaskStatus.ts
@@ -28,6 +28,11 @@ const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
   // stale tickets can be shelved out of context — not from in-flight states
   // (PLANNING / AWAITING_APPROVAL / WORKING) where a worker may own the task;
   // move those to BACKLOG first. ARCHIVED → BACKLOG/WORKING un-archives.
+  // PLANNING → ARCHIVED and BLOCKED → ARCHIVED shelve a row that turned out to
+  // need no work at all (its DoD was met by a sibling; a dead park nobody will
+  // revive) without a two-hop detour through BACKLOG. Measured 2026-09-06: an
+  // architect had to BLOCK an already-satisfied row and page a governor because
+  // neither this tool nor archive_task could close it from PLANNING.
   // BACKLOG → REVIEW is the un-park path: the blocked-timeout sweep parks
   // in-flight tasks (including REVIEW) in BACKLOG, and a human restoring a
   // parked review must be able to send it straight back to the QA queue.
@@ -38,11 +43,11 @@ const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
   // park; BLOCKED is deliberately NOT reachable from human-gated columns
   // (BACKLOG/AWAITING_APPROVAL) — nothing is running there to block.
   BACKLOG: ['PLANNING', 'WORKING', 'REVIEW', 'ARCHIVED'],
-  PLANNING: ['AWAITING_APPROVAL', 'BACKLOG', 'BLOCKED'],
+  PLANNING: ['AWAITING_APPROVAL', 'BACKLOG', 'BLOCKED', 'ARCHIVED'],
   AWAITING_APPROVAL: ['WORKING', 'PLANNING'],
   WORKING: ['REVIEW', 'PLANNING', 'BACKLOG', 'BLOCKED'],
   REVIEW: ['DONE', 'WORKING', 'BACKLOG', 'PLANNING', 'ARCHIVED', 'BLOCKED'],
-  BLOCKED: ['WORKING', 'PLANNING', 'REVIEW', 'BACKLOG'],
+  BLOCKED: ['WORKING', 'PLANNING', 'REVIEW', 'BACKLOG', 'ARCHIVED'],
   DONE: ['BACKLOG', 'WORKING', 'ARCHIVED'],
   ARCHIVED: ['BACKLOG', 'WORKING']
 };
@@ -110,7 +115,9 @@ export function setTaskStatusTool(_state: StateManager): ToolDefinition {
       const effectiveFrom: TaskStatus = task.status === 'BLOCKED'
         ? (task.blockedFromStatus ?? 'WORKING')
         : task.status;
-      if (task.status === 'BLOCKED' && newStatus !== 'BLOCKED'
+      // ARCHIVED is a shelf, not a lifecycle gate: a dead park may be shelved
+      // whatever it was blocked from (the block bookkeeping is cleared below).
+      if (task.status === 'BLOCKED' && newStatus !== 'BLOCKED' && newStatus !== 'ARCHIVED'
         && newStatus !== effectiveFrom && !isValidTransition(effectiveFrom, newStatus)) {
         throw notAllowed(
           'status transition',

--- a/packages/moe-daemon/src/util/claudeHook.test.ts
+++ b/packages/moe-daemon/src/util/claudeHook.test.ts
@@ -222,6 +222,33 @@ describe('writeClaudeHook', () => {
       });
     }
 
+    it('checks ownership without running shell login profiles', () => {
+      const projectPath = makeProjectDir();
+      const bash = findRunnableBash(projectPath);
+      if (!bash) return;
+      const hookPath = writePsHook(projectPath, '#!/usr/bin/env bash\necho \'{"tasks":[]}\'\n');
+      const profileHome = path.join(projectPath, 'home');
+      fs.mkdirSync(profileHome);
+      fs.writeFileSync(path.join(profileHome, '.bash_profile'), 'printf profile-loaded > "$HOME/profile-ran"\nprintf profile-noise\n');
+      const quotedHook = hookPath.replace(/'/g, "''");
+      // Keep only the explicitly supplied Bash candidate. A fallback shell must
+      // not hide the first candidate incorrectly sourcing a user's login profile.
+      const bootstrap = "$env:PATH = ''; $env:ProgramFiles = ''; " +
+        "[Environment]::SetEnvironmentVariable('ProgramFiles(x86)', ''); " +
+        `& '${quotedHook}'; exit $LASTEXITCODE`;
+      const result = spawnSync('pwsh', ['-NoProfile', '-Command', bootstrap], {
+        input: JSON.stringify({ tool_name: 'mcp__moe__moe_start_step' }),
+        cwd: projectPath,
+        env: { ...process.env, HOME: profileHome, CLAUDE_PROJECT_DIR: projectPath, MOE_WORKER_ID: 'worker-1', MOE_BASH_PATH: bash },
+        encoding: 'utf-8',
+        timeout: 25000,
+      });
+
+      expect(result.status, result.stdout + result.stderr).toBe(2);
+      expect(result.stderr).toContain('No active claim for worker worker-1');
+      expect(fs.existsSync(path.join(profileHome, 'profile-ran'))).toBe(false);
+    }, 30000);
+
     it('stays under the PowerShell hook line budget', () => {
       expect(REQUIRE_CLAIM_PS1_CONTENT.trimEnd().split('\n').length).toBeLessThanOrEqual(80);
     });

--- a/packages/moe-daemon/src/util/claudeHook.ts
+++ b/packages/moe-daemon/src/util/claudeHook.ts
@@ -82,7 +82,7 @@ function Test-Bash([string]$Exe) {
     if (-not $Exe -or -not (Test-Path -LiteralPath $Exe -PathType Leaf)) { return $false }
     try {
         $p = [Diagnostics.ProcessStartInfo]::new(); $p.FileName = $Exe; $p.RedirectStandardOutput = $true; $p.RedirectStandardError = $true; $p.UseShellExecute = $false
-        @('-lc', 'printf ok') | ForEach-Object { [void]$p.ArgumentList.Add($_) }
+        @('--noprofile', '--norc', '-c', 'printf ok') | ForEach-Object { [void]$p.ArgumentList.Add($_) }
         $c = [Diagnostics.Process]::Start($p); if (-not $c.WaitForExit(2000)) { $c.Kill($true); return $false }
         return $c.ExitCode -eq 0 -and $c.StandardOutput.ReadToEnd() -eq 'ok'
     } catch { return $false }

--- a/packages/moe-daemon/src/util/version.test.ts
+++ b/packages/moe-daemon/src/util/version.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const packageRoot = fileURLToPath(new URL('../../', import.meta.url));
+const source = fs.readFileSync(new URL('./version.ts', import.meta.url), 'utf8');
+const fixtures: string[] = [];
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) fs.rmSync(fixture, { recursive: true, force: true });
+});
+
+describe('package version discovery', () => {
+  for (const layout of ['src', 'dist', 'bundled']) {
+    it(`reads the actual manifest in the ${layout} layout from another working directory`, () => {
+      const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-version-'));
+      fixtures.push(fixture);
+      const modulePath = path.join(fixture, layout === 'bundled' ? 'util' : `${layout}/util`, 'version.ts');
+      fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+      fs.writeFileSync(modulePath, source);
+      fs.writeFileSync(path.join(fixture, 'package.json'), JSON.stringify({
+        name: 'moe-daemon', type: 'module', version: '9.8.7',
+      }));
+      const result = spawnSync(process.execPath, [
+        '--import', 'tsx', '--input-type=module', '--eval',
+        `import(${JSON.stringify(pathToFileURL(modulePath).href)}).then(module => console.log(module.VERSION))`,
+      ], { cwd: packageRoot, encoding: 'utf8', timeout: 10000, windowsHide: true });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe('9.8.7');
+    });
+  }
+});

--- a/packages/moe-daemon/src/util/version.ts
+++ b/packages/moe-daemon/src/util/version.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+// IDE bundles flatten dist/ beside package.json; source/npm layouts retain it.
+const manifestUrl = [
+  new URL('../package.json', import.meta.url),
+  new URL('../../package.json', import.meta.url),
+].find(candidate => existsSync(candidate));
+
+if (!manifestUrl) throw new Error('The moe-daemon package manifest is missing.');
+
+const manifest: { version?: unknown } = JSON.parse(
+  readFileSync(manifestUrl, 'utf8'),
+);
+
+if (typeof manifest.version !== 'string' || manifest.version.trim() === '') {
+  throw new Error('The moe-daemon package manifest must contain a version.');
+}
+
+export const VERSION = manifest.version;

--- a/scripts/install-all.ps1
+++ b/scripts/install-all.ps1
@@ -1,140 +1,142 @@
 param(
     [switch]$InstallPlugin,
-    [string]$PyCharmVersion = "PyCharm2025.2",
-    [string]$PluginZip = ""
+    [switch]$BuildPlugin,
+    [Alias('PyCharmVersion')]
+    [string]$IdeVersion = "",
+    [string]$PluginZip = "",
+    [ValidateSet('claude', 'codex', 'gemini', 'grok', 'none')]
+    [string]$AgentCommand = 'claude'
 )
 
 $ErrorActionPreference = "Stop"
-
-$shouldInstallPlugin = if ($PSBoundParameters.ContainsKey('InstallPlugin')) { $InstallPlugin.IsPresent } else { $true }
-
 $root = Split-Path -Parent $PSScriptRoot
+# Resolve a supplied relative archive before entering the package directories.
+if ($PluginZip) { $PluginZip = (Resolve-Path -LiteralPath $PluginZip).Path }
 
-Write-Host "Installing Moe daemon..."
-Set-Location "$root\packages\moe-daemon"
-npm install
-if ($LASTEXITCODE -ne 0) { throw "npm install failed in packages/moe-daemon (exit $LASTEXITCODE)" }
-npm run build
-if ($LASTEXITCODE -ne 0) { throw "npm run build failed in packages/moe-daemon (exit $LASTEXITCODE)" }
-
-Write-Host "Installing Moe proxy..."
-Set-Location "$root\packages\moe-proxy"
-npm install
-if ($LASTEXITCODE -ne 0) { throw "npm install failed in packages/moe-proxy (exit $LASTEXITCODE)" }
-npm run build
-if ($LASTEXITCODE -ne 0) { throw "npm run build failed in packages/moe-proxy (exit $LASTEXITCODE)" }
-
-function Resolve-PyCharmVersion([string]$Preferred) {
-    $jbRoot = Join-Path $env:APPDATA "JetBrains"
-    if ($Preferred -and (Test-Path (Join-Path $jbRoot $Preferred))) {
-        return $Preferred
-    }
-
-    if (Test-Path $jbRoot) {
-        $dirs = Get-ChildItem -Path $jbRoot -Directory -Filter "PyCharm*"
-        if ($dirs) {
-            return ($dirs | Sort-Object Name -Descending | Select-Object -First 1).Name
-        }
-    }
-
-    return $Preferred
+function Install-NodePackage([string]$Name) {
+    Write-Host "Installing $Name..."
+    Set-Location -LiteralPath (Join-Path $root "packages\$Name")
+    npm install
+    if ($LASTEXITCODE -ne 0) { throw "npm install failed for $Name (exit $LASTEXITCODE)" }
+    npm run build
+    if ($LASTEXITCODE -ne 0) { throw "npm run build failed for $Name (exit $LASTEXITCODE)" }
+    npm link
+    if ($LASTEXITCODE -ne 0) { throw "npm link failed for $Name (exit $LASTEXITCODE). Check your npm global prefix permissions." }
 }
 
-if ($shouldInstallPlugin) {
-    $zip = $null
-    if ($PluginZip) {
-        if (-not (Test-Path $PluginZip)) {
-            Write-Host "Plugin zip not found at $PluginZip"
-            exit 1
-        }
-        $zip = Get-Item $PluginZip
-    } elseif (Test-Path "$root\installer\assets\moe-jetbrains.zip") {
-        $zip = Get-Item "$root\installer\assets\moe-jetbrains.zip"
-    } else {
-        Write-Host "Building Moe plugin..."
-        $ensureGradle = Join-Path $root "moe-jetbrains\\scripts\\ensure-gradle.ps1"
-        if (Test-Path $ensureGradle) {
-            $gradleBin = & $ensureGradle -ProjectRoot (Join-Path $root "moe-jetbrains")
-            Set-Location "$root\moe-jetbrains"
-            & $gradleBin buildPlugin
-        } else {
-            $gradlew = Join-Path $root "moe-jetbrains\\gradlew.bat"
-            if (-not (Test-Path $gradlew)) {
-                Write-Host "Gradle wrapper not found at $gradlew"
-                Write-Host "Open moe-jetbrains in PyCharm and run Gradle task buildPlugin once."
-                Write-Host "Then re-run this script with -InstallPlugin."
-                exit 0
-            }
-            Set-Location "$root\\moe-jetbrains"
-            & $gradlew buildPlugin
-        }
-
-        $zip = Get-ChildItem "$root\moe-jetbrains\build\distributions\*.zip" | Sort-Object LastWriteTime -Desc | Select-Object -First 1
-        if (-not $zip) {
-            Write-Host "Plugin zip not found in build\\distributions."
-            exit 1
-        }
-    }
-
+function Resolve-IdeDirectory {
     $jbRoot = Join-Path $env:APPDATA "JetBrains"
-    $PyCharmVersion = Resolve-PyCharmVersion $PyCharmVersion
-    $pluginRoot = Join-Path $jbRoot $PyCharmVersion
-    if (-not (Test-Path $pluginRoot)) {
-        Write-Host "PyCharm config not found at $pluginRoot"
-        Write-Host "Set -PyCharmVersion to match your config folder (e.g., PyCharm2025.2)."
-        exit 1
+    if ($IdeVersion) {
+        if ($IdeVersion -notmatch '^[A-Za-z][A-Za-z0-9.\-]*$') { throw "-IdeVersion must be a JetBrains config folder name." }
+        $preferred = Join-Path $jbRoot $IdeVersion
+        if (-not (Test-Path -LiteralPath $preferred -PathType Container)) { throw "JetBrains config not found at $preferred. Open the IDE once, then retry." }
+        return $preferred
     }
+    $ide = if (Test-Path -LiteralPath $jbRoot) {
+        Get-ChildItem -LiteralPath $jbRoot -Directory |
+            Where-Object { $_.Name -match '^(IntelliJIdea|IdeaIC|PyCharm|PyCharmCE|WebStorm|GoLand|CLion|Rider|RubyMine|PhpStorm|DataGrip|RustRover|Aqua)\d' } |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    }
+    if (-not $ide) { throw "No JetBrains IDE config found. Open your IDE once, or install without -InstallPlugin and use Plugins > Install Plugin from Disk." }
+    Write-Host "Using JetBrains config $($ide.Name); select another with -IdeVersion."
+    return $ide.FullName
+}
 
+function Resolve-PluginArchive {
+    if ($PluginZip) { return Get-Item -LiteralPath $PluginZip }
+    $bundled = Join-Path $root "installer\assets\moe-jetbrains.zip"
+    if (Test-Path -LiteralPath $bundled) { return Get-Item -LiteralPath $bundled }
+    Write-Host "Building Moe plugin..."
+    $project = Join-Path $root "moe-jetbrains"
+    $ensureGradle = Join-Path $project "scripts\ensure-gradle.ps1"
+    if (Test-Path -LiteralPath $ensureGradle) {
+        $gradleBin = & $ensureGradle -ProjectRoot $project
+        if ($LASTEXITCODE -ne 0) { throw "Gradle setup failed (exit $LASTEXITCODE)." }
+    } else {
+        $gradleBin = Join-Path $project "gradlew.bat"
+    }
+    if (-not $gradleBin -or -not (Test-Path -LiteralPath $gradleBin)) { throw "Gradle wrapper not found. Build the plugin in your IDE or provide -PluginZip." }
+    Set-Location -LiteralPath $project
+    & $gradleBin buildPlugin | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Gradle buildPlugin failed (exit $LASTEXITCODE). Existing plugin was preserved." }
+    $zip = Get-ChildItem -Path (Join-Path $project "build\distributions\*.zip") |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if (-not $zip) { throw "Plugin zip not found in build\distributions." }
+    return $zip
+}
+
+function Assert-InstallChild([string]$Path, [string]$Parent) {
+    $parentPath = [IO.Path]::GetFullPath($Parent).TrimEnd('\') + '\'
+    if (-not [IO.Path]::GetFullPath($Path).StartsWith($parentPath, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Installer path is outside its target directory: $Path"
+    }
+}
+
+function Install-JetBrainsPlugin {
+    $pluginRoot = Resolve-IdeDirectory
+    $zip = Resolve-PluginArchive
     $pluginsDir = Join-Path $pluginRoot "plugins"
-    if (-not (Test-Path $pluginsDir)) {
-        New-Item -ItemType Directory -Path $pluginsDir | Out-Null
-    }
-
+    New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
     $destDir = Join-Path $pluginsDir "moe-jetbrains"
-    if (Test-Path $destDir) {
-        Remove-Item -Recurse -Force $destDir
-    }
-
-    $tmp = Join-Path $env:TEMP "moe-jetbrains-install"
-    if (Test-Path $tmp) {
-        Remove-Item -Recurse -Force $tmp
-    }
+    $backup = Join-Path $pluginsDir ("moe-jetbrains-backup-" + [guid]::NewGuid().ToString('N'))
+    $tmp = Join-Path $env:TEMP ("moe-jetbrains-install-" + [guid]::NewGuid().ToString('N'))
+    Assert-InstallChild $destDir $pluginsDir
+    Assert-InstallChild $backup $pluginsDir
+    Assert-InstallChild $tmp $env:TEMP
     New-Item -ItemType Directory -Path $tmp | Out-Null
-    Expand-Archive -Path $zip.FullName -DestinationPath $tmp -Force
-
-    if (Test-Path (Join-Path $tmp "lib")) {
-        Move-Item -Path $tmp -Destination $destDir
-    } else {
-        $inner = Get-ChildItem -Path $tmp -Directory |
-            Where-Object { Test-Path (Join-Path $_.FullName "lib") } |
-            Select-Object -First 1
-        if (-not $inner) {
-            throw "Plugin zip layout unexpected. Expected lib/ at root."
+    try {
+        Expand-Archive -LiteralPath $zip.FullName -DestinationPath $tmp
+        $payload = if (Test-Path -LiteralPath (Join-Path $tmp 'lib') -PathType Container) { $tmp } else {
+            (Get-ChildItem -LiteralPath $tmp -Directory | Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'lib') -PathType Container } | Select-Object -First 1).FullName
         }
-        Move-Item -Path $inner.FullName -Destination $destDir
-        Remove-Item -Recurse -Force $tmp
+        if (-not $payload) { throw "Plugin zip layout unexpected. Expected lib/ at root or within the plugin folder. Existing plugin was preserved." }
+        if ($payload -ne $tmp) { Assert-InstallChild $payload $tmp }
+        if (Test-Path -LiteralPath $destDir) { Move-Item -LiteralPath $destDir -Destination $backup }
+        try { Move-Item -LiteralPath $payload -Destination $destDir } catch {
+            if (Test-Path -LiteralPath $backup) {
+                if (Test-Path -LiteralPath $destDir) { Remove-Item -LiteralPath $destDir -Recurse -Force }
+                Move-Item -LiteralPath $backup -Destination $destDir
+            }
+            throw
+        }
+        if (Test-Path -LiteralPath $backup) { Remove-Item -LiteralPath $backup -Recurse -Force }
+    } finally {
+        if (Test-Path -LiteralPath $tmp) { Remove-Item -LiteralPath $tmp -Recurse -Force }
+    }
+    Write-Host "Installed plugin to $destDir"
+    Write-Host "Restart your JetBrains IDE to load the plugin."
+}
+
+Push-Location
+try {
+    $buildsPlugin = ($InstallPlugin -or $BuildPlugin) -and -not $PluginZip -and -not (Test-Path -LiteralPath (Join-Path $root 'installer\assets\moe-jetbrains.zip'))
+    & (Join-Path $PSScriptRoot 'install-dependencies.ps1') -AgentCommand $AgentCommand -WithPlugin:$buildsPlugin
+    Install-NodePackage 'moe-daemon'
+    Install-NodePackage 'moe-proxy'
+    if ($InstallPlugin) { Install-JetBrainsPlugin }
+    elseif ($BuildPlugin) {
+        $builtArchive = Resolve-PluginArchive
+        Write-Host "Plugin archive: $($builtArchive.FullName)"
+        Write-Host 'In your JetBrains IDE: Settings > Plugins > Install Plugin from Disk, then select that archive.'
     }
 
-    Write-Host "Installed plugin to $destDir"
-    Write-Host "Restart PyCharm to load the plugin."
+    $moeHome = Join-Path $env:USERPROFILE '.moe'
+    New-Item -ItemType Directory -Path $moeHome -Force | Out-Null
+    $daemonPkg = Get-Content -LiteralPath (Join-Path $root 'packages\moe-daemon\package.json') -Raw | ConvertFrom-Json
+    $configJson = @{
+        installPath = $root
+        version = $daemonPkg.version
+        updatedAt = (Get-Date -Format 'o')
+    } | ConvertTo-Json
+    [IO.File]::WriteAllText((Join-Path $moeHome 'config.json'), $configJson, (New-Object System.Text.UTF8Encoding($false)))
+    Write-Host "Wrote global config to $moeHome\config.json"
+} finally {
+    Pop-Location
 }
 
-# Write global install config (~/.moe/config.json)
-$moeHome = Join-Path $env:USERPROFILE ".moe"
-if (-not (Test-Path $moeHome)) {
-    New-Item -ItemType Directory -Path $moeHome | Out-Null
+Write-Host 'Done. Next steps:'
+Write-Host '1) Initialize your project: moe-daemon init --project <path>'
+if ($AgentCommand -ne 'none') {
+    Write-Host "2) Launch an architect in another terminal: powershell -NoProfile -ExecutionPolicy Bypass -File `"$PSScriptRoot\moe-agent.ps1`" -Role architect -Command $AgentCommand -Project <path>"
 }
-$daemonPkg = Get-Content (Join-Path $root "packages\moe-daemon\package.json") -Raw | ConvertFrom-Json
-$globalConfig = @{
-    installPath = $root
-    version = $daemonPkg.version
-    updatedAt = (Get-Date -Format "o")
-}
-$globalConfig | ConvertTo-Json | Set-Content -Path (Join-Path $moeHome "config.json") -Encoding UTF8
-Write-Host "Wrote global config to $moeHome\config.json"
-
-Write-Host "Done."
-Write-Host "Next steps:"
-Write-Host "1) Start daemon: node packages/moe-daemon/dist/index.js start --project <path>"
-Write-Host "2) Configure Claude to use moe-proxy (see docs/MCP_SERVER.md)"
-Write-Host "3) Plugin auto-starts the daemon when PyCharm opens a project (if installed)."
+Write-Host '3) Optional JetBrains plugin: re-run with -BuildPlugin to build its ZIP (JDK 17 is installed automatically), then install it through your IDE.'

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -2,6 +2,20 @@
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+agent_command=claude
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --agent|--agent-command)
+            [ "$#" -ge 2 ] || { printf 'Missing agent after --agent\n' >&2; exit 1; }
+            agent_command=$2
+            shift 2
+            ;;
+        --help|-h) printf 'Usage: bash scripts/install-all.sh [--agent claude|codex|gemini|none]\nFor the board plugin, use install-mac.sh --global --skip-mcp --with-plugin.\n'; exit 0 ;;
+        *) printf 'Unknown option: %s\n' "$1" >&2; exit 1 ;;
+    esac
+done
+source "$root/scripts/install-dependencies.sh"
+moe_install_dependencies "$agent_command" false
 
 printf "Installing Moe daemon...\n"
 cd "$root/packages/moe-daemon"
@@ -17,20 +31,15 @@ npm run build
 # so the agent wrappers can resolve daemon/proxy paths when not run from $root.
 moe_home="$HOME/.moe"
 mkdir -p "$moe_home"
-python3 - "$moe_home/config.json" "$root" <<'PYEOF'
-import json, sys, datetime
-cfg_path = sys.argv[1]
-install_path = sys.argv[2]
-cfg = {
-    "installPath": install_path,
-    "version": "0.1.0",
-    "updatedAt": datetime.datetime.utcnow().isoformat() + "Z",
-}
-with open(cfg_path, "w") as f:
-    json.dump(cfg, f, indent=2)
-PYEOF
+node - "$moe_home/config.json" "$root" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const [configPath, installPath] = process.argv.slice(2);
+const { version } = JSON.parse(fs.readFileSync(path.join(installPath, 'packages/moe-daemon/package.json'), 'utf8'));
+fs.writeFileSync(configPath, JSON.stringify({ installPath, version, updatedAt: new Date().toISOString() }, null, 2) + '\n');
+NODE
 printf "Wrote global config to %s/config.json\n" "$moe_home"
 
 printf "Done. Next steps:\n"
-printf "1) Start daemon: node packages/moe-daemon/dist/index.js start --project <path>\n"
-printf "2) Build plugin: open moe-jetbrains in PyCharm and run Gradle task buildPlugin\n"
+printf '1) Initialize your project: node "%s/packages/moe-daemon/dist/index.js" init --project <path>\n' "$root"
+printf "2) Build plugin: open moe-jetbrains in your JetBrains IDE and run Gradle task buildPlugin\n"

--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -1,0 +1,147 @@
+param(
+    [switch]$WithPlugin,
+    [ValidateSet('claude', 'codex', 'gemini', 'grok', 'none')]
+    [string]$AgentCommand = 'claude'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Update-MoeInstallPath([switch]$PreferInstalledNode) {
+    # Package installers update the registry, but this PowerShell session keeps its old PATH.
+    $knownPaths = @(
+        (Join-Path $env:ProgramFiles 'nodejs'),
+        (Join-Path $env:ProgramFiles 'Git\cmd'),
+        (Join-Path $env:APPDATA 'npm'),
+        (Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Links'),
+        (Join-Path $env:USERPROFILE '.local\bin')
+    ) | Where-Object { Test-Path -LiteralPath $_ -PathType Container }
+    $paths = @($env:Path) + $knownPaths + @(
+        [Environment]::GetEnvironmentVariable('Path', 'Machine'),
+        [Environment]::GetEnvironmentVariable('Path', 'User')
+    )
+    if ($PreferInstalledNode) { $paths = @((Join-Path $env:ProgramFiles 'nodejs')) + $paths }
+    $env:Path = (($paths -join ';') -split ';' | Where-Object { $_ } | Select-Object -Unique) -join ';'
+}
+
+function Add-MoeUserPath([string]$Directory) {
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $persistentPaths = @($userPath, [Environment]::GetEnvironmentVariable('Path', 'Machine')) -join ';'
+    $expandedPaths = $persistentPaths -split ';' | ForEach-Object { [Environment]::ExpandEnvironmentVariables($_).TrimEnd('\') }
+    if ($expandedPaths -contains $Directory.TrimEnd('\')) { return }
+    $updatedPath = (@($userPath, $Directory) | Where-Object { $_ }) -join ';'
+    # Registry cmdlet is mockable by the isolated installer harness; do not use setx (it truncates long PATH values).
+    $changed = Set-ItemProperty -LiteralPath 'HKCU:\Environment' -Name Path -Value $updatedPath -PassThru
+    if ($changed) {
+        if (-not ('MoeInstaller.EnvironmentChange' -as [type])) {
+            Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+namespace MoeInstaller {
+    public static class EnvironmentChange {
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr SendMessageTimeout(IntPtr window, uint message, UIntPtr wParam,
+            string lParam, uint flags, uint timeout, out UIntPtr result);
+    }
+}
+'@
+        }
+        $notificationResult = [UIntPtr]::Zero
+        [MoeInstaller.EnvironmentChange]::SendMessageTimeout([IntPtr]0xffff, 0x001a, [UIntPtr]::Zero, 'Environment', 2, 1000, [ref]$notificationResult) | Out-Null
+    }
+    Write-Host 'Updated user PATH. Restart terminals and IDEs opened before this installation.'
+}
+
+function Test-MoeNodeVersion {
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
+    try { $versionText = (node --version 2>$null | Out-String).Trim() } catch { return $false }
+    if ($LASTEXITCODE -ne 0 -or $versionText -notmatch '^v?(\d+)\.(\d+)\.(\d+)$') { return $false }
+    $major = [int]$Matches[1]
+    $minor = [int]$Matches[2]
+    return (($major -eq 22 -and $minor -ge 12) -or $major -eq 24 -or $major -eq 26)
+}
+
+function Install-MoeWinGetPackage([string]$Id) {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw "Installing $Id requires WinGet. Install or update Microsoft's App Installer from https://aka.ms/getwinget, reopen PowerShell, and rerun this installer."
+    }
+    Write-Host "Installing $Id with WinGet..."
+    winget install --id $Id --exact --source winget --accept-package-agreements --accept-source-agreements --silent --disable-interactivity | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "WinGet failed to install $Id (exit $LASTEXITCODE). Resolve the package-manager error above and rerun the installer." }
+    Update-MoeInstallPath -PreferInstalledNode:($Id -eq 'OpenJS.NodeJS.LTS')
+}
+
+function Assert-MoeCommand([string]$Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { throw "$Name is still unavailable after installation. Reopen PowerShell and rerun the installer to refresh PATH." }
+    & $Name --version | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "$Name --version failed (exit $LASTEXITCODE). Repair that dependency and rerun the installer." }
+}
+
+function Find-MoeJdk17 {
+    $candidates = @($env:JAVA_HOME)
+    $javac = Get-Command javac -ErrorAction SilentlyContinue
+    if ($javac -and $javac.Source) { $candidates += Split-Path -Parent (Split-Path -Parent $javac.Source) }
+    foreach ($vendor in @('Eclipse Adoptium', 'Java', 'Microsoft', 'Zulu')) {
+        $vendorPath = Join-Path $env:ProgramFiles $vendor
+        if (Test-Path -LiteralPath $vendorPath) { $candidates += (Get-ChildItem -LiteralPath $vendorPath -Directory).FullName }
+    }
+    foreach ($candidate in ($candidates | Where-Object { $_ } | Select-Object -Unique)) {
+        $release = Join-Path $candidate 'release'
+        if ((Test-Path -LiteralPath $release) -and
+            (Test-Path -LiteralPath (Join-Path $candidate 'bin\java.exe')) -and
+            (Test-Path -LiteralPath (Join-Path $candidate 'bin\javac.exe')) -and
+            ((Get-Content -LiteralPath $release -Raw) -match '(?m)^JAVA_VERSION="17(?:\.|\")')) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Install-MoeAgent([string]$Name) {
+    if ($Name -eq 'none') { return }
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        if ($Name -eq 'claude') {
+            # Anthropic's native Windows package: https://code.claude.com/docs/en/setup
+            Install-MoeWinGetPackage 'Anthropic.ClaudeCode'
+        } else {
+            $packages = @{ codex = '@openai/codex'; gemini = '@google/gemini-cli'; grok = '@xai-official/grok' }
+            $package = $packages[$Name]
+            Write-Host "Installing $Name..."
+            npm install --global $package | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "npm installation of $Name failed (exit $LASTEXITCODE). Check your npm global prefix permissions and rerun." }
+            Update-MoeInstallPath
+        }
+    }
+    Assert-MoeCommand $Name
+    $loginCommand = @{ claude = 'claude auth login'; codex = 'codex login'; gemini = 'gemini'; grok = 'grok login' }[$Name]
+    Write-Host "Agent CLI ready. Sign in to your account once: $loginCommand"
+}
+
+Write-Host 'Checking and installing Moe dependencies...'
+Update-MoeInstallPath
+if (-not (Test-MoeNodeVersion) -or -not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Install-MoeWinGetPackage 'OpenJS.NodeJS.LTS'
+}
+if (-not (Test-MoeNodeVersion)) { throw 'A supported Node.js version is required (22.12+, 24 LTS, or 26). Reopen PowerShell after installation, or update your Node version manager to Node 24.' }
+Assert-MoeCommand 'node'
+Assert-MoeCommand 'npm'
+$npmPrefix = (npm config get prefix | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) { throw "Could not read npm global prefix (exit $LASTEXITCODE)." }
+if ($npmPrefix) {
+    $env:Path = $npmPrefix + ';' + $env:Path
+    Add-MoeUserPath $npmPrefix
+}
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Install-MoeWinGetPackage 'Git.Git' }
+Assert-MoeCommand 'git'
+if ($WithPlugin) {
+    $jdkHome = Find-MoeJdk17
+    if (-not $jdkHome) {
+        Install-MoeWinGetPackage 'EclipseAdoptium.Temurin.17.JDK'
+        $jdkHome = Find-MoeJdk17
+    }
+    if (-not $jdkHome) { throw 'JDK 17 is required by the plugin build. Set JAVA_HOME to your JDK 17 installation and rerun.' }
+    $env:JAVA_HOME = $jdkHome
+    $env:Path = (Join-Path $jdkHome 'bin') + ';' + $env:Path
+    Write-Host 'JDK 17 toolchain ready.'
+}
+Install-MoeAgent $AgentCommand
+Write-Host 'Dependencies ready.'

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Source this helper so newly installed tools are usable by the caller immediately.
+# Official distributions: nodejs.org/dist, npmjs.org (provider-owned CLI packages).
+
+moe_dependency_error() { printf '[ERROR] %s\n' "$*" >&2; return 1; }
+moe_has_tool() {
+    command -v "$1" >/dev/null 2>&1 || return 1
+    if [ "$1" = tmux ]; then "$1" -V >/dev/null 2>&1; else "$1" --version >/dev/null 2>&1; fi
+}
+
+moe_node_ready() {
+    local version major minor
+    version=$(node --version 2>/dev/null) || return 1
+    version=${version#v}
+    major=${version%%.*}
+    minor=${version#*.}; minor=${minor%%.*}
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    { [ "$major" -eq 22 ] && [ "$minor" -ge 12 ]; } || [ "$major" -eq 24 ] || [ "$major" -eq 26 ]
+}
+
+moe_package_install() {
+    local os_name=$1
+    shift
+    local elevate=()
+    if [ "$os_name" = Darwin ]; then
+        if ! moe_has_tool brew; then
+            moe_dependency_error 'Homebrew is required to install missing macOS dependencies. Install it from https://brew.sh (and its Command Line Tools prerequisites), then rerun this installer.'
+            return 1
+        fi
+        brew install "$@" || return
+    else
+        if [ "$(id -u)" -ne 0 ]; then
+            if ! command -v sudo >/dev/null 2>&1; then
+                moe_dependency_error 'Installing system dependencies requires sudo or a root shell. Ask your system administrator to install the listed packages, then rerun.'
+                return 1
+            fi
+            elevate=(sudo)
+        fi
+        if moe_has_tool apt-get; then
+            "${elevate[@]}" apt-get update || return
+            "${elevate[@]}" apt-get install -y "$@" || return
+        elif moe_has_tool dnf; then
+            local translated=() package
+            for package in "$@"; do
+                case "$package" in
+                    openjdk-17-jdk) translated+=(java-17-openjdk-devel) ;;
+                    *) translated+=("$package") ;;
+                esac
+            done
+            "${elevate[@]}" dnf install -y "${translated[@]}" || return
+        else
+            moe_dependency_error "No supported package manager found. Automatic Linux installation supports apt-get or dnf. Install these dependencies with your distribution's manager, then rerun: $*"
+            return 1
+        fi
+    fi
+    hash -r
+}
+
+moe_install_node() (
+    set -e
+    local node_os=$1 node_arch=$2 node_root download_dir line_hash line_file archive='' expected=''
+    node_root="$HOME/.local/share/moe/node"
+    mkdir -p "$node_root" || exit
+    download_dir=$(mktemp -d "$node_root/.download.XXXXXX") || exit
+    trap 'rm -rf "$download_dir"' EXIT
+    local base_url='https://nodejs.org/dist/latest-v24.x'
+    printf 'Installing Node.js 24 from %s\n' "$base_url"
+    curl --fail --location --retry 3 --connect-timeout 20 --max-time 180 --output "$download_dir/SHASUMS256.txt" "$base_url/SHASUMS256.txt" || exit
+    while read -r line_hash line_file; do
+        if [[ "$line_file" =~ ^node-v24\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz$ ]]; then
+            archive=$line_file
+            expected=$line_hash
+            break
+        fi
+    done < "$download_dir/SHASUMS256.txt"
+    if [[ -z "$archive" || ! "$expected" =~ ^[a-fA-F0-9]{64}$ ]]; then
+        moe_dependency_error "Official Node.js checksum manifest has no supported $node_os/$node_arch archive."
+        exit 1
+    fi
+    curl --fail --location --retry 3 --connect-timeout 20 --max-time 300 --output "$download_dir/$archive" "$base_url/$archive" || exit
+    local actual
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$download_dir/$archive") || exit
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$download_dir/$archive") || exit
+    else
+        moe_dependency_error 'A SHA256 tool (sha256sum or shasum) is required; refusing to install an unverified download.'
+        exit 1
+    fi
+    actual=${actual%% *}
+    if [ "$actual" != "$expected" ]; then
+        moe_dependency_error 'Node.js archive checksum mismatch; nothing was extracted.'
+        exit 1
+    fi
+    tar -xzf "$download_dir/$archive" -C "$download_dir" || exit
+    local package_dir=${archive%.tar.gz}
+    "$download_dir/$package_dir/bin/node" --version >/dev/null || exit
+    PATH="$download_dir/$package_dir/bin:$PATH" "$download_dir/$package_dir/bin/npm" --version >/dev/null || exit
+    # A completed version is immutable; select it only after both executables work.
+    if [ ! -e "$node_root/$package_dir" ]; then
+        mv "$download_dir/$package_dir" "$node_root/$package_dir" || exit
+    fi
+    if [ -e "$node_root/current" ] && [ ! -L "$node_root/current" ]; then
+        moe_dependency_error "Expected an installer-owned symlink at $node_root/current; preserve that directory and move it aside before retrying."
+        exit 1
+    fi
+    ln -sfn "$node_root/$package_dir" "$node_root/current" || exit
+)
+
+moe_java17_ready() {
+    local version
+    version=$(javac --version 2>/dev/null) || return 1
+    [[ "$version" == 'javac 17.'* ]]
+}
+
+moe_select_java17() {
+    local candidate version
+    for candidate in "${JAVA_HOME:-}" /usr/lib/jvm/*17* /Library/Java/JavaVirtualMachines/*17*/Contents/Home; do
+        [ -n "$candidate" ] && [ -x "$candidate/bin/javac" ] || continue
+        version=$("$candidate/bin/javac" --version 2>/dev/null) || continue
+        if [[ "$version" == 'javac 17.'* ]]; then
+            export JAVA_HOME="$candidate"
+            export PATH="$JAVA_HOME/bin:$PATH"
+            return 0
+        fi
+    done
+    moe_java17_ready
+}
+
+moe_persist_environment() {
+    local env_dir="$HOME/.local/share/moe" profile line
+    mkdir -p "$env_dir" || return
+    cat > "$env_dir/env.sh" <<'ENV' || return
+# Moe installer tools; existing shell settings are preserved.
+case ":$PATH:" in *":$HOME/.local/share/moe/node/current/bin:"*) ;; *) export PATH="$HOME/.local/share/moe/node/current/bin:$PATH" ;; esac
+case ":$PATH:" in *":$HOME/.local/share/moe/npm/bin:"*) ;; *) export PATH="$HOME/.local/share/moe/npm/bin:$PATH" ;; esac
+ENV
+    line='[ ! -f "$HOME/.local/share/moe/env.sh" ] || . "$HOME/.local/share/moe/env.sh"'
+    local profiles=()
+    case "${SHELL:-/bin/bash}" in
+        */zsh) profiles+=("${ZDOTDIR:-$HOME}/.zshrc" "${ZDOTDIR:-$HOME}/.zprofile") ;;
+        *)
+            profiles+=("$HOME/.bashrc")
+            # Bash reads only the first existing login file in this order.
+            if [ -f "$HOME/.bash_profile" ]; then profiles+=("$HOME/.bash_profile")
+            elif [ -f "$HOME/.bash_login" ]; then profiles+=("$HOME/.bash_login")
+            else profiles+=("$HOME/.profile")
+            fi
+            ;;
+    esac
+    for profile in "${profiles[@]}"; do
+        if ! [ -f "$profile" ] || ! grep -Fqx "$line" "$profile"; then
+            printf '\n# Moe command PATH\n%s\n' "$line" >> "$profile" || return
+        fi
+    done
+    printf 'New terminals load Moe tools automatically. In an existing terminal run:\n  . "$HOME/.local/share/moe/env.sh"\n'
+}
+
+moe_install_dependencies() {
+    local agent=${1:-claude} with_plugin=${2:-false} os_name arch node_os node_arch
+    case "$agent" in claude|codex|gemini|none) ;; *) moe_dependency_error 'Choose --agent claude, codex, gemini, or none.'; return 1 ;; esac
+    os_name=$(uname -s)
+    case "$os_name" in Darwin) node_os=darwin ;; Linux) node_os=linux ;; *) moe_dependency_error "Automatic dependency installation does not support $os_name. Use the Windows PowerShell installer on Windows."; return 1 ;; esac
+    arch=$(uname -m)
+    case "$arch" in x86_64|amd64) node_arch=x64 ;; arm64|aarch64) node_arch=arm64 ;; *) moe_dependency_error "Unsupported CPU architecture: $arch (supported: x64, arm64)."; return 1 ;; esac
+    export PATH="$HOME/.local/share/moe/node/current/bin:$HOME/.local/share/moe/npm/bin:$PATH"
+    local missing=() tool required=(git python3 curl tar)
+    if [ "$os_name" = Linux ]; then required+=(tmux); fi
+    for tool in "${required[@]}"; do
+        moe_has_tool "$tool" || missing+=("$tool")
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+        # CA roots are required before downloading official Node distributions.
+        moe_package_install "$os_name" "${missing[@]}" ca-certificates || return
+        for tool in "${required[@]}"; do
+            moe_has_tool "$tool" || { moe_dependency_error "$tool is still unavailable after dependency installation."; return 1; }
+        done
+    fi
+    if ! moe_node_ready || ! moe_has_tool npm; then
+        moe_install_node "$node_os" "$node_arch" || return
+        hash -r
+        moe_node_ready && moe_has_tool npm || { moe_dependency_error 'Installed Node.js/npm could not run on this system.'; return 1; }
+    fi
+    if [ "$with_plugin" = true ] && ! moe_select_java17; then
+        if [ "$os_name" = Darwin ]; then
+            moe_package_install "$os_name" openjdk@17 || return
+            local brew_java
+            brew_java=$(brew --prefix openjdk@17) || return
+            export JAVA_HOME="$brew_java/libexec/openjdk.jdk/Contents/Home"
+            export PATH="$JAVA_HOME/bin:$PATH"
+        else
+            moe_package_install "$os_name" openjdk-17-jdk || return
+        fi
+        moe_select_java17 || { moe_dependency_error 'JDK 17 is still unavailable after installation.'; return 1; }
+    fi
+    if [ "$agent" != none ] && ! moe_has_tool "$agent"; then
+        local package
+        case "$agent" in claude) package=@anthropic-ai/claude-code ;; codex) package=@openai/codex ;; gemini) package=@google/gemini-cli ;; esac
+        npm install --global --prefix "$HOME/.local/share/moe/npm" "$package" || return
+        hash -r
+        moe_has_tool "$agent" || { moe_dependency_error "$agent is still unavailable after installation."; return 1; }
+    fi
+    # Keep the user's npm configuration intact. Only this installer uses a user prefix
+    # when its current global prefix is unwritable (or Node was installed by Moe).
+    local prefix
+    prefix=$(npm prefix -g) || return
+    if [ ! -w "$prefix" ] || [[ "$(command -v node)" == "$HOME/.local/share/moe/"* ]]; then
+        export npm_config_prefix="$HOME/.local/share/moe/npm"
+    fi
+    moe_persist_environment || return
+    printf '[OK] Node.js, npm, Git, Python3, curl and tar are ready.\n'
+    if [ "$agent" != none ]; then
+        printf '[OK] %s is installed. Run %s once to sign in before launching a Moe agent.\n' "$agent" "$agent"
+    fi
+}

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -35,6 +35,7 @@ GLOBAL_INSTALL=false
 INSTALL_LAUNCHD=false
 SKIP_MCP=false
 BUILD_PLUGIN=false
+AGENT_COMMAND=claude
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -54,6 +55,11 @@ while [[ $# -gt 0 ]]; do
             BUILD_PLUGIN=true
             shift
             ;;
+        --agent|--agent-command)
+            [ "$#" -ge 2 ] || { echo 'Missing agent after --agent' >&2; exit 1; }
+            AGENT_COMMAND=$2
+            shift 2
+            ;;
         --help|-h)
             echo "Moe Installation Script"
             echo ""
@@ -61,7 +67,8 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --global, -g     Install daemon and proxy globally via npm"
-            echo "  --with-plugin    Build JetBrains plugin (requires JDK 17+)"
+            echo "  --with-plugin    Install JDK 17 if needed and build the JetBrains plugin"
+            echo "  --agent NAME     Install claude (default), codex, gemini, or none"
             echo "  --with-launchd   Install launchd plist for auto-start (Mac only)"
             echo "  --skip-mcp       Skip MCP configuration setup"
             echo "  --help, -h       Show this help"
@@ -79,9 +86,13 @@ echo -e "${BLUE}   Moe Installation for Mac${NC}"
 echo -e "${BLUE}================================${NC}"
 echo ""
 
-# Run doctor check first
+# Install prerequisites before checking them. Source preserves the new tool PATH.
+source "$SCRIPT_DIR/install-dependencies.sh"
+moe_install_dependencies "$AGENT_COMMAND" "$BUILD_PLUGIN"
+
+# Run doctor check after dependency installation
 echo -e "${YELLOW}Step 1: Checking prerequisites...${NC}"
-if ! "$SCRIPT_DIR/doctor.sh"; then
+if ! bash "$SCRIPT_DIR/doctor.sh"; then
     echo -e "${RED}Prerequisites check failed. Please fix the issues above.${NC}"
     exit 1
 fi
@@ -145,114 +156,10 @@ if [ "$BUILD_PLUGIN" = true ]; then
 
     cd "$ROOT_DIR/moe-jetbrains"
 
-    # Check for Java and find a compatible version (17-23, not 24+)
-    JAVA_CMD=""
-
-    # Check for Homebrew Java installations first
-    for v in 21 17 20 19 18; do
-        if [ -d "/opt/homebrew/opt/openjdk@$v" ]; then
-            export JAVA_HOME="/opt/homebrew/opt/openjdk@$v"
-            JAVA_CMD="$JAVA_HOME/bin/java"
-            echo -e "${GREEN}[OK]${NC} Using Homebrew OpenJDK $v"
-            break
-        elif [ -d "/usr/local/opt/openjdk@$v" ]; then
-            export JAVA_HOME="/usr/local/opt/openjdk@$v"
-            JAVA_CMD="$JAVA_HOME/bin/java"
-            echo -e "${GREEN}[OK]${NC} Using Homebrew OpenJDK $v (Intel)"
-            break
-        fi
-    done
-
-    # Fall back to system Java
-    if [ -z "$JAVA_CMD" ]; then
-        if ! command -v java &> /dev/null; then
-            echo -e "${RED}[ERROR]${NC} Java not found. Install JDK 17-21: brew install openjdk@21"
-            exit 1
-        fi
-        JAVA_CMD="java"
-    fi
-
-    # Check Java version (must be 17-23, Gradle doesn't support 24+ yet)
-    JAVA_VERSION=$($JAVA_CMD -version 2>&1 | head -n1 | sed -n 's/.*version "\([^"]*\)".*/\1/p')
-    JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d'.' -f1)
-
-    # Handle old format (1.8.x)
-    if [ "$JAVA_MAJOR" = "1" ]; then
-        JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d'.' -f2)
-    fi
-
-    if [ "$JAVA_MAJOR" -lt 17 ] 2>/dev/null; then
-        echo -e "${RED}[ERROR]${NC} Java 17+ required. Found version $JAVA_VERSION"
-        echo -e "    ${YELLOW}Install:${NC} brew install openjdk@21"
-        exit 1
-    fi
-
-    if [ "$JAVA_MAJOR" -ge 24 ] 2>/dev/null; then
-        echo -e "${RED}[ERROR]${NC} Java $JAVA_MAJOR is too new - Gradle doesn't support it yet"
-        echo -e "    ${YELLOW}Install Java 21:${NC} brew install openjdk@21"
-        echo -e "    ${YELLOW}Then run:${NC} export JAVA_HOME=/opt/homebrew/opt/openjdk@21"
-        exit 1
-    fi
-
-    echo -e "${GREEN}[OK]${NC} Java version $JAVA_VERSION"
-
-    # Ensure gradle wrapper exists
+    # Dependency bootstrap selected JDK 17. Use the repository's pinned wrapper.
     if [ ! -f "gradle/wrapper/gradle-wrapper.jar" ]; then
-        echo -e "${YELLOW}[INFO]${NC} Gradle wrapper missing, downloading..."
-
-        # Try to use system gradle to generate wrapper
-        if command -v gradle &> /dev/null; then
-            gradle wrapper --gradle-version 8.5
-        else
-            # Download gradle wrapper jar directly
-            mkdir -p gradle/wrapper
-            WRAPPER_URL="https://raw.githubusercontent.com/gradle/gradle/v8.5.0/gradle/wrapper/gradle-wrapper.jar"
-            WRAPPER_JAR="gradle/wrapper/gradle-wrapper.jar"
-            WRAPPER_JAR_TMP="${WRAPPER_JAR}.tmp"
-            # Track temp file for cleanup on failure
-            TEMP_FILES_TO_CLEANUP+=("$WRAPPER_JAR_TMP")
-
-            if command -v curl &> /dev/null; then
-                curl -sL "$WRAPPER_URL" -o "$WRAPPER_JAR_TMP"
-            elif command -v wget &> /dev/null; then
-                wget -q "$WRAPPER_URL" -O "$WRAPPER_JAR_TMP"
-            else
-                echo -e "${RED}[ERROR]${NC} Cannot download gradle wrapper. Install gradle: brew install gradle"
-                exit 1
-            fi
-
-            # Verify the download succeeded and file is not empty
-            if [ ! -s "$WRAPPER_JAR_TMP" ]; then
-                echo -e "${RED}[ERROR]${NC} Failed to download gradle wrapper (empty or missing)"
-                rm -f "$WRAPPER_JAR_TMP"
-                exit 1
-            fi
-
-            # Basic sanity check: gradle-wrapper.jar should be a valid JAR (ZIP format)
-            if command -v file &> /dev/null; then
-                FILE_TYPE=$(file -b "$WRAPPER_JAR_TMP")
-                if [[ ! "$FILE_TYPE" =~ "Java archive" && ! "$FILE_TYPE" =~ "Zip archive" ]]; then
-                    echo -e "${RED}[ERROR]${NC} Downloaded file is not a valid JAR: $FILE_TYPE"
-                    rm -f "$WRAPPER_JAR_TMP"
-                    exit 1
-                fi
-            fi
-
-            # Move temp file to final location (atomic on same filesystem)
-            mv "$WRAPPER_JAR_TMP" "$WRAPPER_JAR"
-
-            # Create wrapper properties if missing
-            if [ ! -f "gradle/wrapper/gradle-wrapper.properties" ]; then
-                cat > gradle/wrapper/gradle-wrapper.properties << 'PROPEOF'
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-PROPEOF
-            fi
-        fi
-        echo -e "${GREEN}[OK]${NC} Gradle wrapper setup complete"
+        echo '[ERROR] Gradle wrapper is missing. Download a complete source ZIP or clone of Moe.' >&2
+        exit 1
     fi
 
     # Build plugin
@@ -290,17 +197,15 @@ if [ "$SKIP_MCP" = false ]; then
         if [ "$GLOBAL_INSTALL" = true ] && command -v moe-proxy &> /dev/null; then
             PROXY_CMD="moe-proxy"
         else
-            PROXY_CMD="node $ROOT_DIR/packages/moe-proxy/dist/index.js"
+            PROXY_CMD="node"
         fi
 
-        cat > "$MCP_CONFIG_FILE" << EOF
-{
-  "moe": {
-    "command": "$PROXY_CMD",
-    "env": {}
-  }
-}
-EOF
+        node - "$MCP_CONFIG_FILE" "$PROXY_CMD" "$ROOT_DIR/packages/moe-proxy/dist/index.js" <<'NODE'
+const fs = require('node:fs');
+const [configPath, command, proxyPath] = process.argv.slice(2);
+const args = command === 'node' ? [proxyPath] : [];
+fs.writeFileSync(configPath, JSON.stringify({ moe: { command, args, env: {} } }, null, 2) + '\n');
+NODE
         echo -e "${GREEN}[OK]${NC} Created MCP config at $MCP_CONFIG_FILE"
     fi
     echo ""
@@ -349,13 +254,13 @@ if [ ! -f "$HOME/.moe/projects.json" ]; then
 fi
 
 # Write global install config so other projects can find this installation
-cat > "$HOME/.moe/config.json" << EOF
-{
-  "installPath": "$ROOT_DIR",
-  "version": "0.1.0",
-  "updatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-EOF
+node - "$HOME/.moe/config.json" "$ROOT_DIR" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const [configPath, installPath] = process.argv.slice(2);
+const { version } = JSON.parse(fs.readFileSync(path.join(installPath, 'packages/moe-daemon/package.json'), 'utf8'));
+fs.writeFileSync(configPath, JSON.stringify({ installPath, version, updatedAt: new Date().toISOString() }, null, 2) + '\n');
+NODE
 echo -e "${GREEN}[OK]${NC} Created ~/.moe directory and config.json"
 echo ""
 
@@ -374,11 +279,14 @@ else
 fi
 echo ""
 echo "2. Run an AI agent:"
-echo "   $SCRIPT_DIR/moe-agent.sh --role architect --project /path/to/your/project"
+if [ "$AGENT_COMMAND" != none ]; then
+    printf '   bash "%s/moe-agent.sh" --role architect --command %s --project /path/to/your/project\n' "$SCRIPT_DIR" "$AGENT_COMMAND"
+else
+    echo '   Choose and install an agent CLI before launching one (--agent claude, codex, or gemini).'
+fi
 echo ""
 echo "   Tip: If agents can't find node, set MOE_NODE_COMMAND:"
 echo "     export MOE_NODE_COMMAND=/path/to/node"
 echo ""
-echo "3. Or use Claude Code directly with MCP:"
-echo "   MOE_PROJECT_PATH=/path/to/project claude"
+echo '3. Open the board, create an epic and task, and move the task to Planning.'
 echo ""

--- a/scripts/moe-agent.ps1
+++ b/scripts/moe-agent.ps1
@@ -1402,12 +1402,20 @@ function Start-HeartbeatSidecar {
     if ($env:MOE_DISABLE_HEARTBEAT -eq '1') { return $null }
     $intervalSec = 60
     if ($env:MOE_HEARTBEAT_INTERVAL_SEC -match '^\d+$') { $intervalSec = [int]$env:MOE_HEARTBEAT_INTERVAL_SEC }
-    $maxDurationSec = 7200
+    # Default 24h, and the loop below also stops the moment this wrapper
+    # process is gone. The old 2h ceiling silently ended the heartbeat under
+    # every long LIVE session (a governor's chat_wait loop, an architect
+    # planning several rows in one CLI, a QA mid-review): measured 2026-09-06,
+    # two architects' lastActivityAt froze at exactly launch+2h and the
+    # governor seat was deleted by the stale sweep twice while its CLI was
+    # running. The daemon never auto-releases WORKING/PLANNING on idle, so a
+    # longer heartbeat defeats nothing; it only stops live seats being reaped.
+    $maxDurationSec = 86400
     if ($env:MOE_HEARTBEAT_MAX_DURATION_SEC -match '^\d+$') { $maxDurationSec = [int]$env:MOE_HEARTBEAT_MAX_DURATION_SEC }
 
     try {
         $script:CurrentHeartbeatJob = Start-Job -Name "moe-heartbeat-$WorkerId" -ScriptBlock {
-            param($ProxyScript, $ProjectPath, $WorkerId, $IntervalSec, $MaxDurationSec)
+            param($ProxyScript, $ProjectPath, $WorkerId, $IntervalSec, $MaxDurationSec, $WrapperPid)
             $env:MOE_PROJECT_PATH = $ProjectPath
             $rpc = (@{
                 jsonrpc = "2.0"
@@ -1418,9 +1426,12 @@ function Start-HeartbeatSidecar {
             $deadline = (Get-Date).AddSeconds($MaxDurationSec)
             while ((Get-Date) -lt $deadline) {
                 Start-Sleep -Seconds $IntervalSec
+                # The wrapper that owns this job is gone (TerminateProcess leaves
+                # no finally): stop heartbeating on behalf of a dead seat.
+                if ($WrapperPid -and -not (Get-Process -Id $WrapperPid -ErrorAction SilentlyContinue)) { break }
                 try { $rpc | & node $ProxyScript 2>&1 | Out-Null } catch {}
             }
-        } -ArgumentList $ProxyScript, $ProjectPath, $WorkerId, $intervalSec, $maxDurationSec
+        } -ArgumentList $ProxyScript, $ProjectPath, $WorkerId, $intervalSec, $maxDurationSec, $PID
         return $script:CurrentHeartbeatJob
     } catch {
         Write-Host "[WARN] Failed to start heartbeat sidecar: $_ — a long silent verification step risks REVIEW self-heal eviction." -ForegroundColor Yellow
@@ -3201,6 +3212,24 @@ $script:ResumeEscalated = $false
 $resumeMaxAttempts = 5
 if ($env:MOE_RESUME_MAX_ATTEMPTS -match '^\d+$') { $resumeMaxAttempts = [int]$env:MOE_RESUME_MAX_ATTEMPTS }
 
+# Launch-failure tracking. A CLI that exits non-zero within MOE_LAUNCH_FAIL_SEC
+# of starting never did any work: provider usage limit, expired credential, a
+# crash at launch. Measured 2026-09-06: an account usage limit made every
+# claude seat exit 1 at launch; each wrapper burned its resume budget in about
+# three minutes, posted "pausing auto-resume" and then idled for hours after
+# the limit had reset -- twice in one night. Such exits are NOT counted against
+# the resume budget; the relaunch backs off exponentially instead (the held
+# task stays held, so nothing needs a release).
+$script:LaunchFailStreak = 0
+$script:LaunchFailBackoffSec = 0
+$script:CliLaunchedAt = $null
+$launchFailSec = 120
+if ($env:MOE_LAUNCH_FAIL_SEC -match '^\d+$') { $launchFailSec = [int]$env:MOE_LAUNCH_FAIL_SEC }
+$launchBackoffBaseSec = 60
+if ($env:MOE_LAUNCH_BACKOFF_BASE_SEC -match '^\d+$') { $launchBackoffBaseSec = [int]$env:MOE_LAUNCH_BACKOFF_BASE_SEC }
+$launchBackoffMaxSec = 900
+if ($env:MOE_LAUNCH_BACKOFF_MAX_SEC -match '^\d+$') { $launchBackoffMaxSec = [int]$env:MOE_LAUNCH_BACKOFF_MAX_SEC }
+
 # --- Self-restart when this script's own bytes change on disk -----------------
 # PowerShell parses the ENTIRE script at process start, so a long-lived polling
 # loop executes its ORIGINAL bytes for its whole life. A fix can therefore be
@@ -3234,8 +3263,13 @@ try {
 do {
     if (-not $firstRun) {
         Write-Host ""
-        Write-Host "Agent idle, checking for tasks in ${PollInterval} seconds... (Ctrl+C to stop)"
-        Start-Sleep -Seconds $PollInterval
+        if ($script:LaunchFailBackoffSec -gt 0) {
+            Write-Host "[launch-failure] Backing off $($script:LaunchFailBackoffSec)s before relaunching (streak $($script:LaunchFailStreak)); the held task stays held. (Ctrl+C to stop)" -ForegroundColor Yellow
+            Start-Sleep -Seconds $script:LaunchFailBackoffSec
+        } else {
+            Write-Host "Agent idle, checking for tasks in ${PollInterval} seconds... (Ctrl+C to stop)"
+            Start-Sleep -Seconds $PollInterval
+        }
         Write-Host "Relaunching agent..."
     }
 
@@ -3881,6 +3915,7 @@ $mentionsJson
         $claimPrompt = $dynamicContext.TrimEnd()
     }
 
+    $script:CliLaunchedAt = Get-Date
     if ($cliType -eq "codex") {
         # Check codex is available
         $codexCheck = Get-Command $Command -ErrorAction SilentlyContinue
@@ -4416,6 +4451,29 @@ $mentionsJson
                 Stop-HeartbeatSidecar
             }
         }
+    }
+
+    # Launch-failure classification (tracker declared above the main loop).
+    $cliElapsedSec = if ($script:CliLaunchedAt) { [int]((Get-Date) - $script:CliLaunchedAt).TotalSeconds } else { -1 }
+    $cliExitForLaunch = if ($null -ne $script:CliExitCode) { [int]$script:CliExitCode } else { 0 }
+    if ($cliExitForLaunch -ne 0 -and $cliElapsedSec -ge 0 -and $cliElapsedSec -lt $launchFailSec) {
+        $script:LaunchFailStreak++
+        # Not a mid-task death: give the resume attempt back.
+        if ($script:ResumeAttempts -gt 0) { $script:ResumeAttempts-- }
+        $launchBackoffPow = [math]::Min($script:LaunchFailStreak - 1, 10)
+        $script:LaunchFailBackoffSec = [int][math]::Min($launchBackoffMaxSec, $launchBackoffBaseSec * [math]::Pow(2, $launchBackoffPow))
+        Write-Host "[launch-failure] CLI exited $cliExitForLaunch after ${cliElapsedSec}s, before doing any work (streak $($script:LaunchFailStreak)): provider usage limit, credential, or a crash at launch. Not counted against the resume budget; next relaunch in $($script:LaunchFailBackoffSec)s." -ForegroundColor Yellow
+        if ($script:LaunchFailStreak -eq 3 -and $generalChannelId) {
+            $launchFailMsg = "@governors ${WorkerId}: CLI exits within ${launchFailSec}s of launch (exit $cliExitForLaunch, $($script:LaunchFailStreak) in a row) - provider usage limit or credential problem, not a task problem. Wrapper is backing off up to ${launchBackoffMaxSec}s between relaunches and keeps its task; no release needed."
+            try { Invoke-MoeRpc -Tool "chat_send" -Args @{ channel = $generalChannelId; workerId = $WorkerId; content = $launchFailMsg } | Out-Null } catch {}
+        }
+    } else {
+        if ($script:LaunchFailStreak -ge 3 -and $generalChannelId) {
+            $launchOkMsg = "${WorkerId}: CLI launches again (ran ${cliElapsedSec}s, exit $cliExitForLaunch) after $($script:LaunchFailStreak) launch failures."
+            try { Invoke-MoeRpc -Tool "chat_send" -Args @{ channel = $generalChannelId; workerId = $WorkerId; content = $launchOkMsg } | Out-Null } catch {}
+        }
+        $script:LaunchFailStreak = 0
+        $script:LaunchFailBackoffSec = 0
     }
 
     # -------- Post-flight: shutdown rituals after CLI exits --------

--- a/scripts/moe-agent.ps1
+++ b/scripts/moe-agent.ps1
@@ -3821,16 +3821,26 @@ $mentionsJson
     # from --append-system-prompt-file, so its bug surface is the (mostly quote-free) role directive.
     $codexUsesFileContext = $false
     if ($cliType -eq "codex") {
+        # The project-shared .codex/agent-instructions.md keeps ONLY the
+        # identity-free role doc (it is a project_doc fallback). Everything
+        # per-seat -- "You ARE ... workerId=", the claimed task, inbox, routed
+        # mentions -- goes to a per-PROCESS file handed to codex with
+        # `-c model_instructions_file=<path>` at launch. Measured 2026-09-06:
+        # two codex seats launched 2 s apart both read the shared file, the
+        # second write won, and one seat worked the other's task under the
+        # other's workerId for ten minutes.
         $agentInstructionsPath = Join-Path (Join-Path $projectPath ".codex") "agent-instructions.md"
         $codexDir = Split-Path $agentInstructionsPath -Parent
         if (-not (Test-Path $codexDir)) { New-Item -ItemType Directory -Force -Path $codexDir | Out-Null }
+        $systemAppend | Set-Content -Path $agentInstructionsPath -Encoding UTF8
+        $script:CodexSeatInstructionsFile = Join-Path $env:TEMP "moe-codex-instructions-$Role-$PID.md"
         $fileBody = $systemAppend
         if ($dynamicContext) {
             $fileBody += "`n`n# Session Context (per-iteration)`n" + $dynamicContext
             $codexUsesFileContext = $true
         }
-        $fileBody | Set-Content -Path $agentInstructionsPath -Encoding UTF8
-        Write-Host "Agent instructions written to: $agentInstructionsPath"
+        $fileBody | Set-Content -Path $script:CodexSeatInstructionsFile -Encoding UTF8
+        Write-Host "Agent instructions written to: $($script:CodexSeatInstructionsFile) (shared role doc: $agentInstructionsPath)"
     } elseif ($cliType -eq "gemini") {
         $geminiInstructionsDir = Join-Path $projectPath ".gemini"
         if (-not (Test-Path $geminiInstructionsDir)) {
@@ -3936,7 +3946,7 @@ $mentionsJson
                 if ($claimPromptBody) {
                     $shortPrompt = $claimPromptBody
                 } else {
-                    $shortPrompt = "Session context (routed mentions, pre-flight data) is in .codex/agent-instructions.md - read it. If a routed_mentions block is present, reply to each tagged message via moe.chat_send as workerId $WorkerId. Then follow your role doc."
+                    $shortPrompt = "Session context (routed mentions, pre-flight data) is in $($script:CodexSeatInstructionsFile) - read it. If a routed_mentions block is present, reply to each tagged message via moe.chat_send as workerId $WorkerId. Then follow your role doc."
                 }
             } else {
                 $shortPrompt = $claimPrompt
@@ -3972,15 +3982,26 @@ $mentionsJson
         # it for all CLIs; this must match).
         Start-HeartbeatSidecar -ProxyScript $proxyScript -ProjectPath $projectPath -WorkerId $WorkerId | Out-Null
         try {
+            # Per-seat config overrides, passed on argv so they can never be
+            # clobbered by a sibling seat writing the shared .codex/config.toml:
+            # this seat's instructions file, and its workerId for the proxy's
+            # injection (codex does not forward the wrapper's environment to
+            # MCP servers). Values are not valid TOML, so codex keeps them as
+            # strings; forward slashes keep the path free of TOML escapes.
+            $codexSeatArgs = @()
+            if ($script:CodexSeatInstructionsFile) {
+                $codexSeatArgs += @('-c', "model_instructions_file=$($script:CodexSeatInstructionsFile.Replace('\', '/'))")
+            }
+            $codexSeatArgs += @('-c', "mcp_servers.moe.env.MOE_WORKER_ID=$WorkerId")
             if ($CodexExec) {
-                # Non-interactive exec mode: codex exec -C <project> --full-auto --sandbox workspace-write "<prompt>"
-                Write-Host "Command: $Command exec -C `"$projectPath`" --full-auto --sandbox workspace-write `"<prompt>`""
-                & $Command @CommandArgs exec -C "$projectPath" --full-auto --sandbox workspace-write "$shortPrompt"
+                # Non-interactive exec mode: codex -c <seat overrides> exec -C <project> --full-auto --sandbox workspace-write "<prompt>"
+                Write-Host "Command: $Command $($codexSeatArgs -join ' ') exec -C `"$projectPath`" --full-auto --sandbox workspace-write `"<prompt>`""
+                & $Command @CommandArgs @codexSeatArgs exec -C "$projectPath" --full-auto --sandbox workspace-write "$shortPrompt"
                 $script:CliExitCode = $LASTEXITCODE
             } else {
-                # Interactive TUI mode: codex -C <project> "<prompt>"
-                Write-Host "Command: $Command -C `"$projectPath`" `"<prompt>`""
-                & $Command @CommandArgs -C "$projectPath" "$shortPrompt"
+                # Interactive TUI mode: codex -c <seat overrides> -C <project> "<prompt>"
+                Write-Host "Command: $Command $($codexSeatArgs -join ' ') -C `"$projectPath`" `"<prompt>`""
+                & $Command @CommandArgs @codexSeatArgs -C "$projectPath" "$shortPrompt"
                 $script:CliExitCode = $LASTEXITCODE
             }
         } finally {

--- a/scripts/moe-agent.sh
+++ b/scripts/moe-agent.sh
@@ -19,6 +19,15 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 PROXY_PATH_OVERRIDE="${MOE_PROXY_PATH:-}"
 DAEMON_PATH_OVERRIDE="${MOE_DAEMON_PATH:-}"
 
+# GUI terminals may not source the profile installed by the dependency helper.
+# Add its agent CLIs without changing the caller's existing command priority.
+if [ -d "$HOME/.local/share/moe/npm/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/.local/share/moe/npm/bin:"*) ;;
+        *) export PATH="${PATH:+$PATH:}$HOME/.local/share/moe/npm/bin" ;;
+    esac
+fi
+
 # Auto-detect node binary from common installation locations
 find_node() {
     # 1. Explicit override via env var
@@ -29,7 +38,13 @@ find_node() {
         fi
     fi
 
-    # 2. node on PATH
+    # 2. Moe's managed runtime replaces unsupported system Node installations.
+    if [ -x "$HOME/.local/share/moe/node/current/bin/node" ]; then
+        echo "$HOME/.local/share/moe/node/current/bin/node"
+        return 0
+    fi
+
+    # 3. node on PATH
     if command -v node &> /dev/null; then
         echo "node"
         return 0
@@ -68,6 +83,11 @@ find_node() {
 }
 
 NODE_CMD=$(find_node)
+# Agent CLI shebangs and their children must use the same selected Node.
+NODE_EXECUTABLE=$(command -v "$NODE_CMD" 2>/dev/null || true)
+if [ -n "$NODE_EXECUTABLE" ] && [ -f "$NODE_EXECUTABLE" ]; then
+    export PATH="$(dirname "$NODE_EXECUTABLE"):$PATH"
+fi
 NODE_VERSION=$("$NODE_CMD" --version 2>/dev/null || echo "unknown")
 if [ "$NODE_VERSION" = "unknown" ]; then
     echo -e "${RED}[ERROR]${NC} Could not find node. Set MOE_NODE_COMMAND=/path/to/node"
@@ -2605,7 +2625,7 @@ attr_summary_load() {
     [ -f "$1/summary" ] || return 1
     local k v
     while IFS='=' read -r k v; do
-        v="${v%$''}"
+        v="${v%$'\r'}"
         case "$k" in
             N_CANDIDATES) ATTR_N_CANDIDATES="$v" ;;
             N_INFERRED) ATTR_N_INFERRED="$v" ;;

--- a/scripts/moe-agent.sh
+++ b/scripts/moe-agent.sh
@@ -4758,7 +4758,10 @@ $PROMPT_BODY"
             echo "Command: $COMMAND_BIN ${COMMAND_ARGV[*]} exec -C \"$PROJECT\" --full-auto --sandbox workspace-write \"<prompt>\""
             set +e
 
-            "$COMMAND_BIN" "${COMMAND_ARGV[@]}" exec -C "$PROJECT" --full-auto --sandbox workspace-write "$SHORT_PROMPT"
+            # Per-seat workerId on argv (PS twin parity): codex does not forward the
+            # wrapper's environment to MCP servers, and the shared .codex/config.toml
+            # cannot carry a per-seat value without sibling seats clobbering it.
+            "$COMMAND_BIN" "${COMMAND_ARGV[@]}" -c "mcp_servers.moe.env.MOE_WORKER_ID=$WORKER_ID" exec -C "$PROJECT" --full-auto --sandbox workspace-write "$SHORT_PROMPT"
 
             CLI_EXIT_CODE=$?
 
@@ -4770,7 +4773,7 @@ $PROMPT_BODY"
             echo "Command: $COMMAND_BIN ${COMMAND_ARGV[*]} -C \"$PROJECT\" \"<prompt>\""
             set +e
 
-            "$COMMAND_BIN" "${COMMAND_ARGV[@]}" -C "$PROJECT" "$SHORT_PROMPT"
+            "$COMMAND_BIN" "${COMMAND_ARGV[@]}" -c "mcp_servers.moe.env.MOE_WORKER_ID=$WORKER_ID" -C "$PROJECT" "$SHORT_PROMPT"
 
             CLI_EXIT_CODE=$?
 

--- a/scripts/moe-agent.sh
+++ b/scripts/moe-agent.sh
@@ -1817,20 +1817,27 @@ sys.exit(1)
 # then yanks the task out from under a live session. This sidecar pings
 # moe.heartbeat on a timer from a background subshell (inherits moe_rpc and
 # every resolved proxy/project variable, so no separate resolution needed) so
-# a genuinely-alive-but-quiet session keeps its task. Bounded by
-# MOE_HEARTBEAT_MAX_DURATION_SEC so a truly-hung CLI still eventually goes
-# stale — this extends the self-heal's patience window, it does not defeat it.
+# a genuinely-alive-but-quiet session keeps its task. Runs for the whole CLI
+# lifetime (24h default via MOE_HEARTBEAT_MAX_DURATION_SEC, and it stops when
+# this wrapper process is gone). The old 2h ceiling silently ended the
+# heartbeat under every long LIVE session; measured 2026-09-06, architects'
+# lastActivityAt froze at exactly launch+2h and a governor seat was deleted by
+# the stale sweep while its CLI was running. The daemon never auto-releases
+# WORKING/PLANNING on idle, so a longer heartbeat defeats nothing.
 HEARTBEAT_PID=""
 start_heartbeat_sidecar() {
     local worker_id="$1"
     if [ "${MOE_DISABLE_HEARTBEAT:-}" = "1" ]; then return; fi
     local interval_sec="${MOE_HEARTBEAT_INTERVAL_SEC:-60}"
-    local max_duration_sec="${MOE_HEARTBEAT_MAX_DURATION_SEC:-7200}"
+    local max_duration_sec="${MOE_HEARTBEAT_MAX_DURATION_SEC:-86400}"
+    local wrapper_pid=$$
     (
         set +e
         end_time=$(( $(date +%s) + max_duration_sec ))
         while [ "$(date +%s)" -lt "$end_time" ]; do
             sleep "$interval_sec"
+            # The wrapper that owns this job is gone: stop heartbeating for a dead seat.
+            kill -0 "$wrapper_pid" 2>/dev/null || break
             moe_rpc "heartbeat" "{\"workerId\":\"$worker_id\"}" >/dev/null 2>&1
         done
     ) &
@@ -3741,6 +3748,23 @@ case "$RESUME_MAX_ATTEMPTS" in
     ''|*[!0-9]*) RESUME_MAX_ATTEMPTS=5 ;;
 esac
 
+# Launch-failure tracking (PS twin parity). A CLI that exits non-zero within
+# MOE_LAUNCH_FAIL_SEC of starting never did any work: provider usage limit,
+# expired credential, a crash at launch. Measured 2026-09-06: an account usage
+# limit made every claude seat exit 1 at launch; each wrapper burned its resume
+# budget in about three minutes, posted "pausing auto-resume" and idled for
+# hours after the limit had reset. Such exits are NOT counted against the
+# resume budget; the relaunch backs off exponentially instead.
+LAUNCH_FAIL_STREAK=0
+LAUNCH_FAIL_BACKOFF_SEC=0
+CLI_LAUNCHED_AT=""
+LAUNCH_FAIL_SEC="${MOE_LAUNCH_FAIL_SEC:-120}"
+case "$LAUNCH_FAIL_SEC" in ''|*[!0-9]*) LAUNCH_FAIL_SEC=120 ;; esac
+LAUNCH_BACKOFF_BASE_SEC="${MOE_LAUNCH_BACKOFF_BASE_SEC:-60}"
+case "$LAUNCH_BACKOFF_BASE_SEC" in ''|*[!0-9]*) LAUNCH_BACKOFF_BASE_SEC=60 ;; esac
+LAUNCH_BACKOFF_MAX_SEC="${MOE_LAUNCH_BACKOFF_MAX_SEC:-900}"
+case "$LAUNCH_BACKOFF_MAX_SEC" in ''|*[!0-9]*) LAUNCH_BACKOFF_MAX_SEC=900 ;; esac
+
 # --- Self-restart when this script's own bytes change on disk -----------------
 # The shell reads this file incrementally, so an edit to a running script can
 # even corrupt the current execution; either way a long-lived loop keeps serving
@@ -3764,10 +3788,15 @@ MOE_WRAPPER_ARGV=("$@")
 while [ "$LOOP_RUNNING" = true ]; do
     if [ "$FIRST_RUN" = false ]; then
         echo ""
-        echo -e "${YELLOW}Agent idle, checking for tasks in ${POLL_INTERVAL} seconds... (Ctrl+C to stop)${NC}"
-        # Honor --poll-interval (PS parity); a hardcoded 2s near-busy-spins a
-        # full CLI relaunch every 2s on an idle worker.
-        sleep "$POLL_INTERVAL"
+        if [ "${LAUNCH_FAIL_BACKOFF_SEC:-0}" -gt 0 ]; then
+            echo -e "${YELLOW}[launch-failure]${NC} Backing off ${LAUNCH_FAIL_BACKOFF_SEC}s before relaunching (streak $LAUNCH_FAIL_STREAK); the held task stays held. (Ctrl+C to stop)"
+            sleep "$LAUNCH_FAIL_BACKOFF_SEC"
+        else
+            echo -e "${YELLOW}Agent idle, checking for tasks in ${POLL_INTERVAL} seconds... (Ctrl+C to stop)${NC}"
+            # Honor --poll-interval (PS parity); a hardcoded 2s near-busy-spins a
+            # full CLI relaunch every 2s on an idle worker.
+            sleep "$POLL_INTERVAL"
+        fi
         echo -e "${BLUE}Relaunching agent...${NC}"
     fi
 
@@ -4679,6 +4708,7 @@ $PROMPT_BODY"
         PROMPT=""
     fi
 
+    CLI_LAUNCHED_AT=$(date +%s)
     start_heartbeat_sidecar "$WORKER_ID"
 
     if [ "$CLI_TYPE" = "codex" ]; then
@@ -5194,6 +5224,36 @@ PYEOF
     fi
 
     stop_heartbeat_sidecar
+
+    # Launch-failure classification (tracker declared above the main loop).
+    CLI_ELAPSED_SEC=-1
+    if [ -n "$CLI_LAUNCHED_AT" ]; then CLI_ELAPSED_SEC=$(( $(date +%s) - CLI_LAUNCHED_AT )); fi
+    CLI_EXIT_FOR_LAUNCH="${CLI_EXIT_CODE:-0}"
+    if [ "$CLI_EXIT_FOR_LAUNCH" != "0" ] && [ "$CLI_ELAPSED_SEC" -ge 0 ] && [ "$CLI_ELAPSED_SEC" -lt "$LAUNCH_FAIL_SEC" ]; then
+        LAUNCH_FAIL_STREAK=$((LAUNCH_FAIL_STREAK + 1))
+        # Not a mid-task death: give the resume attempt back.
+        if [ "$RESUME_ATTEMPTS" -gt 0 ]; then RESUME_ATTEMPTS=$((RESUME_ATTEMPTS - 1)); fi
+        LAUNCH_BACKOFF_POW=$((LAUNCH_FAIL_STREAK - 1))
+        if [ "$LAUNCH_BACKOFF_POW" -gt 10 ]; then LAUNCH_BACKOFF_POW=10; fi
+        LAUNCH_FAIL_BACKOFF_SEC=$(( LAUNCH_BACKOFF_BASE_SEC * (1 << LAUNCH_BACKOFF_POW) ))
+        if [ "$LAUNCH_FAIL_BACKOFF_SEC" -gt "$LAUNCH_BACKOFF_MAX_SEC" ]; then LAUNCH_FAIL_BACKOFF_SEC="$LAUNCH_BACKOFF_MAX_SEC"; fi
+        echo -e "${YELLOW}[launch-failure]${NC} CLI exited $CLI_EXIT_FOR_LAUNCH after ${CLI_ELAPSED_SEC}s, before doing any work (streak $LAUNCH_FAIL_STREAK): provider usage limit, credential, or a crash at launch. Not counted against the resume budget; next relaunch in ${LAUNCH_FAIL_BACKOFF_SEC}s."
+        if [ "$LAUNCH_FAIL_STREAK" -eq 3 ] && [ -n "${GENERAL_CHANNEL_ID:-}" ]; then
+            LAUNCH_FAIL_MSG="@governors $WORKER_ID: CLI exits within ${LAUNCH_FAIL_SEC}s of launch (exit $CLI_EXIT_FOR_LAUNCH, $LAUNCH_FAIL_STREAK in a row) - provider usage limit or credential problem, not a task problem. Wrapper is backing off up to ${LAUNCH_BACKOFF_MAX_SEC}s between relaunches and keeps its task; no release needed."
+            moe_rpc chat_send \
+                "$($PYTHON_CMD -c "import json,sys; print(json.dumps({'channel':sys.argv[1],'workerId':sys.argv[2],'content':sys.argv[3]}))" "$GENERAL_CHANNEL_ID" "$WORKER_ID" "$LAUNCH_FAIL_MSG" 2>/dev/null)" \
+                > /dev/null 2>&1 || true
+        fi
+    else
+        if [ "$LAUNCH_FAIL_STREAK" -ge 3 ] && [ -n "${GENERAL_CHANNEL_ID:-}" ]; then
+            LAUNCH_OK_MSG="$WORKER_ID: CLI launches again (ran ${CLI_ELAPSED_SEC}s, exit $CLI_EXIT_FOR_LAUNCH) after $LAUNCH_FAIL_STREAK launch failures."
+            moe_rpc chat_send \
+                "$($PYTHON_CMD -c "import json,sys; print(json.dumps({'channel':sys.argv[1],'workerId':sys.argv[2],'content':sys.argv[3]}))" "$GENERAL_CHANNEL_ID" "$WORKER_ID" "$LAUNCH_OK_MSG" 2>/dev/null)" \
+                > /dev/null 2>&1 || true
+        fi
+        LAUNCH_FAIL_STREAK=0
+        LAUNCH_FAIL_BACKOFF_SEC=0
+    fi
 
     # -------- Post-flight: shutdown rituals after CLI exits --------
     # Dirty snapshot FIRST: after the CLI exits and before any daemon RPC, so

--- a/scripts/tests/agent-runtime.test.mjs
+++ b/scripts/tests/agent-runtime.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const windows = process.platform === 'win32';
+const bash = windows ? 'C:/Program Files/Git/bin/bash.exe' : '/bin/bash';
+const shellPath = value => windows ? value.replaceAll('\\', '/').replace(/^([A-Z]):/i, (_, drive) => `/${drive.toLowerCase()}`) : value;
+
+function run(t, mode = 'bootstrap') {
+    const dir = mkdtempSync(path.join(tmpdir(), 'moe gui runtime '));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const home = path.join(dir, 'home');
+    const bin = path.join(dir, 'bin');
+    const nodeBin = path.join(home, '.local/share/moe/node/current/bin');
+    const agentBin = path.join(home, '.local/share/moe/npm/bin');
+    for (const folder of [bin, nodeBin, agentBin]) mkdirSync(folder, { recursive: true });
+    const executable = (file, body) => writeFileSync(file, '#!/bin/bash\n' + body, { mode: 0o755 });
+    executable(path.join(bin, 'dirname'), 'printf "%s\\n" "${1%/*}"\n');
+    executable(path.join(agentBin, 'claude'), 'exit 0\n');
+    const nodeBody = version => `command -v claude >/dev/null || exit 9\nprintf '${version}\\n'\n`;
+    if (mode !== 'path') executable(path.join(nodeBin, 'node'), nodeBody('v24.99.0'));
+    if (mode === 'path') executable(path.join(bin, 'node'), nodeBody('v22.99.0'));
+    if (mode === 'old-system') executable(path.join(bin, 'node'), nodeBody('v12.99.0'));
+    const override = path.join(bin, 'requested-node');
+    if (mode === 'override') executable(override, nodeBody('v26.99.0'));
+
+    return spawnSync(bash, ['--noprofile', '--norc', '-c', 'PATH="$MOE_FIXTURE_PATH"; export PATH; exec /bin/bash "$MOE_FIXTURE_SCRIPT" --help'], {
+        encoding: 'utf8', timeout: 15000,
+        env: { ...process.env, HOME: shellPath(home), MOE_FIXTURE_PATH: shellPath(bin), MOE_FIXTURE_SCRIPT: shellPath(path.join(root, 'scripts/moe-agent.sh')), MOE_NODE_COMMAND: mode === 'override' ? shellPath(override) : '', MOE_WORKER_ID: '' }
+    });
+}
+
+for (const [mode, version] of [['bootstrap', 'v24.99.0'], ['path', 'v22.99.0'], ['old-system', 'v24.99.0'], ['override', 'v26.99.0']]) {
+    test(`agent wrapper discovers bootstrap CLI bins and honors ${mode} Node selection`, t => {
+        const result = run(t, mode);
+        assert.equal(result.status, 0, result.stdout + result.stderr);
+        assert.ok(result.stdout.includes(version), result.stdout);
+        assert.ok(result.stdout.includes('Moe Agent Wrapper'), 'help should succeed without daemon or project setup');
+    });
+}

--- a/scripts/tests/dependencies.test.mjs
+++ b/scripts/tests/dependencies.test.mjs
@@ -1,0 +1,225 @@
+// Dependency installation is exercised entirely with fake tools and a temporary HOME.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const helper = fileURLToPath(new URL('../install-dependencies.sh', import.meta.url));
+const windows = process.platform === 'win32';
+const bash = windows ? 'C:/Program Files/Git/bin/bash.exe' : '/bin/bash';
+const shellPath = value => windows ? value.replaceAll('\\', '/').replace(/^([A-Z]):/i, (_, drive) => `/${drive.toLowerCase()}`) : value;
+
+function fixture(t, ready = ['git', 'python3', 'curl', 'tar', 'node', 'npm', 'claude', 'tmux']) {
+  assert.ok(fs.existsSync(helper), 'dependency bootstrap helper is missing');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'moe dependency test '));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  for (const name of ['bin', 'ready', 'profile', 'global/bin']) fs.mkdirSync(path.join(dir, name), { recursive: true });
+  for (const name of ready) fs.writeFileSync(path.join(dir, 'ready', name), '');
+  const stub = `#!/bin/bash
+tool="\${0##*/}"
+printf '%s %s\\n' "$tool" "$*" >> "$MOE_FIXTURE/log"
+case "$tool" in
+  uname) if [ "$1" = '-m' ]; then echo "\${MOE_FIXTURE_ARCH:-x86_64}"; else echo "\${MOE_FIXTURE_OS:-Linux}"; fi ;;
+  id) echo 0 ;;
+  sudo) exec "$@" ;;
+  apt-get|dnf|brew)
+    [ "$tool" = "\${MOE_FIXTURE_MANAGER:-apt-get}" ] || exit 127
+    [ "\${MOE_FIXTURE_FAIL_MANAGER:-0}" = 0 ] || exit 41
+    if [ "$1" = '--version' ]; then echo fixture; exit; fi
+    if [ "$1" = '--prefix' ]; then echo "$MOE_FIXTURE/brew"; exit; fi
+    for dep in git python3 curl tar javac tmux; do touch "$MOE_FIXTURE/ready/$dep"; done
+    ;;
+  sha256sum|shasum)
+    if [ "\${MOE_FIXTURE_BAD_HASH:-0}" = 1 ]; then printf '%064d  archive\\n' 1; else printf '%064d  archive\\n' 0; fi
+    ;;
+  node)
+    [ -f "$MOE_FIXTURE/ready/node" ] || exit 127
+    echo "\${MOE_FIXTURE_NODE_VERSION:-v24.99.0}"
+    ;;
+  npm)
+    [ -f "$MOE_FIXTURE/ready/npm" ] || exit 127
+    node --version >/dev/null || exit 127
+    if [ "$1" = '--version' ]; then echo 11.0.0; exit; fi
+    if [ "$1" = 'prefix' ]; then echo "$MOE_FIXTURE/global"; exit; fi
+    if [ "$1" = 'config' ]; then echo "$MOE_FIXTURE/global"; exit; fi
+    [ "\${MOE_FIXTURE_FAIL_NPM:-0}" = 0 ] || exit 42
+    command=''
+    prefix=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --prefix) prefix="$2"; shift ;;
+        @anthropic-ai/claude-code) command=claude ;;
+        @openai/codex) command=codex ;;
+        @google/gemini-cli) command=gemini ;;
+      esac
+      shift
+    done
+    if [ -n "$command" ]; then
+      mkdir -p "$prefix/bin"
+      printf '#!/bin/bash\\necho fixture-agent\\n' > "$prefix/bin/$command"
+      chmod +x "$prefix/bin/$command"
+    fi
+    ;;
+  curl)
+    [ -f "$MOE_FIXTURE/ready/curl" ] || exit 127
+    [ "$1" != '--version' ] || { echo fixture; exit; }
+    output=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in -o|--output) output="$2"; shift ;; esac
+      shift
+    done
+    if [[ "$output" == *SHASUMS256.txt ]]; then
+      printf '%064d  node-v24.99.0-%s-%s.tar.gz\\n' 0 "\${MOE_FIXTURE_NODE_OS:-linux}" "\${MOE_FIXTURE_NODE_ARCH:-x64}" > "$output"
+    else printf 'fixture archive' > "$output"; fi
+    ;;
+  tar)
+    [ -f "$MOE_FIXTURE/ready/tar" ] || exit 127
+    [ "$1" != '--version' ] || { echo fixture; exit; }
+    dest=''
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = '-C' ]; then dest="$2"; shift; fi
+      shift
+    done
+    package="$dest/node-v24.99.0-\${MOE_FIXTURE_NODE_OS:-linux}-\${MOE_FIXTURE_NODE_ARCH:-x64}"
+    mkdir -p "$package/bin"
+    printf '#!/bin/bash\\necho v24.99.0\\n' > "$package/bin/node"
+    cp "$MOE_FIXTURE/bin/npm" "$package/bin/npm"
+    touch "$MOE_FIXTURE/ready/npm"
+    chmod +x "$package/bin/node" "$package/bin/npm"
+    ;;
+  javac) [ -f "$MOE_FIXTURE/ready/javac" ] || exit 127; echo 'javac 17.0.99' ;;
+  git|python3|claude|codex|gemini|tmux)
+    [ -f "$MOE_FIXTURE/ready/$tool" ] || exit 127
+    echo fixture
+    ;;
+esac
+`;
+  for (const name of ['uname', 'id', 'sudo', 'apt-get', 'dnf', 'brew', 'sha256sum', 'shasum', 'node', 'npm', 'curl', 'tar', 'javac', 'git', 'python3', 'claude', 'codex', 'gemini', 'tmux']) {
+    fs.writeFileSync(path.join(dir, 'bin', name), stub, { mode: 0o755 });
+  }
+  return dir;
+}
+
+function run(dir, agent = 'claude', plugin = false, extra = {}) {
+  const script = path.join(dir, 'run.sh');
+  // System JDK discovery is a boundary like apt/brew: constrain it to fake javac.
+  // Hosted CI machines may have JDK17 in JAVA_HOME or the helper's absolute paths.
+  fs.writeFileSync(script, `#!/bin/bash\nset -e\nexport PATH="$MOE_FIXTURE/bin:$PATH"\nsource "$MOE_HELPER"\nmoe_select_java17() { moe_java17_ready; }\nmoe_install_dependencies "$MOE_AGENT" "$MOE_PLUGIN"\nprintf 'BOOTSTRAP_OK\\n'\n`);
+  return spawnSync(bash, [shellPath(script)], {
+    encoding: 'utf8', timeout: 45000,
+    env: {
+      ...process.env, HOME: shellPath(path.join(dir, 'profile')), SHELL: '/bin/bash',
+      PATH: `${path.join(dir, 'bin')}${path.delimiter}${process.env.PATH}`,
+      MOE_FIXTURE: shellPath(dir), MOE_HELPER: shellPath(helper), MOE_AGENT: agent, MOE_PLUGIN: String(plugin),
+      ...extra,
+    },
+  });
+}
+const log = dir => fs.readFileSync(path.join(dir, 'log'), 'utf8');
+const passed = result => assert.equal(result.status, 0, result.stdout + result.stderr);
+
+test('existing compatible tools require no downloads, package installs, or npm config changes', t => {
+  const dir = fixture(t);
+  passed(run(dir));
+  assert.doesNotMatch(log(dir), /apt-get (update|install)|dnf install|brew install|curl --fail|npm install|npm config set/);
+});
+
+for (const blocked of ['.local', '.local/share/moe/env.sh', '.profile']) {
+  test(`environment persistence stops when ${blocked} cannot be written`, t => {
+    const dir = fixture(t);
+    const target = path.join(dir, 'profile', blocked);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (blocked === '.local') fs.writeFileSync(target, 'existing file');
+    else fs.mkdirSync(target);
+    const result = run(dir);
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.doesNotMatch(result.stdout, /BOOTSTRAP_OK|New terminals load Moe tools automatically/);
+  });
+}
+
+for (const [manager, osName] of [['apt-get', 'Linux'], ['dnf', 'Linux'], ['brew', 'Darwin']]) {
+  test(`missing native dependencies are installed through ${manager}`, t => {
+    const dir = fixture(t, ['node', 'npm', 'claude']);
+    passed(run(dir, 'claude', false, { MOE_FIXTURE_MANAGER: manager, MOE_FIXTURE_OS: osName }));
+    assert.match(log(dir), new RegExp(`${manager} .*install.*git`));
+    assert.match(log(dir), /python3/);
+  });
+}
+
+test('missing Node and npm install a checksum-verified official Node 24 archive', t => {
+  const dir = fixture(t, ['git', 'python3', 'curl', 'tar', 'claude']);
+  passed(run(dir));
+  const calls = log(dir);
+  assert.match(calls, /https:\/\/nodejs.org\/dist\/latest-v24.x\/SHASUMS256.txt/);
+  assert.match(calls, /sha256sum|shasum/);
+  assert.ok(calls.indexOf('sha256sum ') < calls.indexOf('tar -xzf '));
+  assert.equal(fs.existsSync(path.join(dir, 'profile/.local/share/moe/node/current/bin/node')), true);
+});
+
+test('old Node is upgraded and a checksum mismatch prevents extraction', t => {
+  const dir = fixture(t);
+  const result = run(dir, 'claude', false, { MOE_FIXTURE_NODE_VERSION: 'v18.20.0', MOE_FIXTURE_BAD_HASH: '1' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /checksum/i);
+  assert.doesNotMatch(log(dir), /tar -xzf/);
+});
+
+for (const [agent, pkg] of [['claude', '@anthropic-ai/claude-code'], ['codex', '@openai/codex'], ['gemini', '@google/gemini-cli']]) {
+  test(`missing ${agent} installs its official package in a user prefix`, t => {
+    const dir = fixture(t, ['git', 'python3', 'curl', 'tar', 'node', 'npm']);
+    passed(run(dir, agent));
+    assert.match(log(dir), new RegExp(`npm install --global --prefix .* ${pkg.replaceAll('/', '\\/')}`));
+    assert.doesNotMatch(log(dir), /npm config set|sudo npm/);
+    assert.equal(fs.existsSync(path.join(dir, `profile/.local/share/moe/npm/bin/${agent}`)), true);
+  });
+}
+
+test('none skips agent installation and profile setup is idempotent', t => {
+  const dir = fixture(t);
+  passed(run(dir, 'none'));
+  passed(run(dir, 'none'));
+  assert.doesNotMatch(log(dir), /npm install/);
+  const profile = fs.readFileSync(path.join(dir, 'profile/.bashrc'), 'utf8');
+  assert.equal((profile.match(/env\.sh/g) || []).length, 2, 'one guarded source line contains the path twice');
+});
+
+test('missing package manager fails actionably without a success claim', t => {
+  const dir = fixture(t, ['node', 'npm']);
+  const result = run(dir, 'none', false, { MOE_FIXTURE_MANAGER: 'none' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /package manager|Homebrew/);
+  assert.doesNotMatch(result.stdout, /BOOTSTRAP_OK/);
+});
+
+test('agent installation failure propagates and never claims ready', t => {
+  const dir = fixture(t, ['git', 'python3', 'curl', 'tar', 'node', 'npm']);
+  const result = run(dir, 'codex', false, { MOE_FIXTURE_FAIL_NPM: '1' });
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /BOOTSTRAP_OK/);
+});
+
+test('plugin opt-in installs JDK17 while ordinary bootstrap skips Java', t => {
+  const dir = fixture(t);
+  passed(run(dir, 'none', true));
+  assert.match(log(dir), /apt-get .*install.*openjdk-17-jdk/);
+});
+
+test('plugin dependency fixtures ignore Java installed outside their fake tool set', t => {
+  const dir = fixture(t);
+  const unrelatedJava = path.join(dir, 'unrelated-java');
+  fs.mkdirSync(path.join(unrelatedJava, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(unrelatedJava, 'bin', 'javac'), '#!/bin/bash\necho "javac 17.0.99"\n', { mode: 0o755 });
+  passed(run(dir, 'none', true, { JAVA_HOME: shellPath(unrelatedJava) }));
+  assert.match(log(dir), /apt-get .*install.*openjdk-17-jdk/);
+});
+
+test('Bash login startup selection is preserved when only .profile exists', t => {
+  const dir = fixture(t);
+  fs.writeFileSync(path.join(dir, 'profile/.profile'), 'export EXISTING_SETTING=keep\n');
+  passed(run(dir, 'none'));
+  assert.equal(fs.existsSync(path.join(dir, 'profile/.bash_profile')), false, 'creating .bash_profile hides the existing .profile');
+  assert.match(fs.readFileSync(path.join(dir, 'profile/.profile'), 'utf8'), /EXISTING_SETTING=keep/);
+});

--- a/scripts/tests/install-dependencies-windows.test.mjs
+++ b/scripts/tests/install-dependencies-windows.test.mjs
@@ -1,0 +1,172 @@
+// Dependency bootstrap tests never invoke real npm, winget or agent CLIs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const helper = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../install-dependencies.ps1');
+const options = { skip: process.platform !== 'win32' };
+const quote = value => `'${value.replaceAll("'", "''")}'`;
+
+function run(t, { tools = ['node', 'npm', 'git', 'claude', 'winget'], nodeVersion = 'v24.13.0', args = '', fail = '', jdk = false } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'moe deps test '));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  for (const folder of ['profile', 'appdata', 'localappdata', 'programfiles', 'bin']) mkdirSync(path.join(dir, folder));
+  const runner = path.join(dir, 'runner.ps1');
+  writeFileSync(runner, `
+$ErrorActionPreference = 'Stop'
+$env:ProgramFiles = ${quote(path.join(dir, 'programfiles'))}
+$env:JAVA_HOME = ''
+$env:Path = ${quote(path.join(dir, 'version-manager'))} + ';' + $env:Path
+$global:availableTools = @(${tools.map(quote).join(', ')})
+$global:nodeVersion = ${quote(nodeVersion)}
+$global:failInstall = ${quote(fail)}
+$global:logFile = ${quote(path.join(dir, 'calls.txt'))}
+Set-Content -LiteralPath $global:logFile -Value ''
+function Get-Command {
+    param([string]$Name, $ErrorAction)
+    if ($Name -in @('node', 'npm', 'git', 'claude', 'codex', 'gemini', 'grok', 'winget')) {
+        if ($Name -in $global:availableTools) { return [pscustomobject]@{ Name = $Name; Source = $Name } }
+        return $null
+    }
+    Microsoft.PowerShell.Core\\Get-Command -Name $Name -ErrorAction SilentlyContinue
+}
+function node { $global:LASTEXITCODE = 0; $global:nodeVersion }
+function git { $global:LASTEXITCODE = 0; 'git version 2.50.0' }
+function claude { $global:LASTEXITCODE = 0; 'claude 2.0.0' }
+function codex { $global:LASTEXITCODE = 0; 'codex 1.0.0' }
+function gemini { $global:LASTEXITCODE = 0; 'gemini 1.0.0' }
+function grok { $global:LASTEXITCODE = 0; 'grok 1.0.0' }
+function Set-ItemProperty {
+    param([string]$LiteralPath, [string]$Name, [string]$Value)
+    if ($LiteralPath -ne 'HKCU:\\Environment' -or $Name -ne 'Path') { throw 'Unexpected registry write in dependency bootstrap' }
+    Set-Content -LiteralPath ${quote(path.join(dir, 'user-path.txt'))} -Value $Value
+}
+function Install-FakeJdk {
+    $jdkDir = Join-Path $env:ProgramFiles 'Eclipse Adoptium\\jdk-17.0.19'
+    New-Item -ItemType Directory -Path (Join-Path $jdkDir 'bin') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $jdkDir 'release') -Value 'JAVA_VERSION="17.0.19"'
+    Set-Content -LiteralPath (Join-Path $jdkDir 'bin\\java.exe') -Value 'fixture'
+    Set-Content -LiteralPath (Join-Path $jdkDir 'bin\\javac.exe') -Value 'fixture'
+}
+function winget {
+    $line = $args -join ' '
+    Add-Content -LiteralPath $global:logFile -Value ('winget ' + $line)
+    $global:LASTEXITCODE = if ($line -like ('*' + $global:failInstall + '*') -and $global:failInstall) { 47 } else { 0 }
+    if ($global:LASTEXITCODE -ne 0) { return }
+    if ($line -match 'OpenJS.NodeJS.LTS') { $global:availableTools += @('node', 'npm'); $global:nodeVersion = 'v24.13.0' }
+    if ($line -match 'Git.Git') { $global:availableTools += 'git' }
+    if ($line -match 'Anthropic.ClaudeCode') { $global:availableTools += 'claude' }
+    if ($line -match 'EclipseAdoptium.Temurin.17.JDK') { Install-FakeJdk }
+}
+function npm {
+    $line = $args -join ' '
+    Add-Content -LiteralPath $global:logFile -Value ('npm ' + $line)
+    $global:LASTEXITCODE = if ($line -like ('*' + $global:failInstall + '*') -and $global:failInstall) { 47 } else { 0 }
+    if ($global:LASTEXITCODE -ne 0) { return }
+    if ($line -eq 'config get prefix') { ${quote(path.join(dir, 'bin'))}; return }
+    if ($line -match '@openai/codex') { $global:availableTools += 'codex' }
+    if ($line -match '@google/gemini-cli') { $global:availableTools += 'gemini' }
+    if ($line -match '@xai-official/grok') { $global:availableTools += 'grok' }
+    if ($line -match '@anthropic-ai/claude-code') { $global:availableTools += 'claude' }
+    'npm 11.0.0'
+}
+${jdk ? 'Install-FakeJdk' : ''}
+& ${quote(helper)} ${args}
+$env:JAVA_HOME | Set-Content -LiteralPath ${quote(path.join(dir, 'java-home.txt'))}
+$env:Path | Set-Content -LiteralPath ${quote(path.join(dir, 'runtime-path.txt'))}
+`);
+  const result = spawnSync('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-File', runner], {
+    encoding: 'utf8', timeout: 20000,
+    env: { ...process.env, USERPROFILE: path.join(dir, 'profile'), APPDATA: path.join(dir, 'appdata'), LOCALAPPDATA: path.join(dir, 'localappdata'), ProgramFiles: path.join(dir, 'programfiles'), JAVA_HOME: '', MOE_GRADLE_HOME: '', MOE_GRADLE_BIN: '' },
+  });
+  return { ...result, dir, calls: readFileSync(path.join(dir, 'calls.txt'), 'utf8') };
+}
+
+function pass(result) { assert.equal(result.status, 0, result.stdout + result.stderr); }
+
+test('Windows ready dependencies do not invoke package installation', options, t => {
+  const result = run(t);
+  pass(result);
+  assert.doesNotMatch(result.calls, /winget |npm install/);
+  assert.match(result.stdout, /claude/);
+});
+
+test('Windows npm command directory is persisted in user PATH', options, t => {
+  const result = run(t);
+  pass(result);
+  assert.equal(existsSync(path.join(result.dir, 'user-path.txt')), true, 'future terminals must discover installed npm CLIs');
+  assert.ok(readFileSync(path.join(result.dir, 'user-path.txt'), 'utf8').includes(path.join(result.dir, 'bin')));
+});
+
+test('Windows ready Node keeps the existing version manager priority', options, t => {
+  const result = run(t);
+  pass(result);
+  const entries = readFileSync(path.join(result.dir, 'runtime-path.txt'), 'utf8').trim().split(';');
+  assert.equal(entries[1], path.join(result.dir, 'version-manager'));
+});
+
+test('Windows missing Node npm Git and default Claude are provisioned', options, t => {
+  const result = run(t, { tools: ['winget'] });
+  pass(result);
+  for (const id of ['OpenJS.NodeJS.LTS', 'Git.Git', 'Anthropic.ClaudeCode']) assert.ok(result.calls.includes(id), `${id} must be installed`);
+  assert.match(result.calls, /--accept-package-agreements/);
+});
+
+test('Windows unsupported Node is upgraded before installation continues', options, t => {
+  const result = run(t, { nodeVersion: 'v20.19.0' });
+  pass(result);
+  assert.match(result.calls, /OpenJS.NodeJS.LTS/);
+});
+
+test('Windows missing winget fails with App Installer recovery instructions', options, t => {
+  const result = run(t, { tools: [] });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /App Installer/);
+  assert.doesNotMatch(result.calls, /winget /);
+});
+
+test('Windows package manager failure stops at the failed dependency', options, t => {
+  const result = run(t, { tools: ['winget'], fail: 'OpenJS.NodeJS.LTS' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /47/);
+  assert.doesNotMatch(result.calls, /Git.Git|Anthropic.ClaudeCode/);
+});
+
+for (const [agent, pkg] of [['codex', '@openai/codex'], ['gemini', '@google/gemini-cli'], ['grok', '@xai-official/grok']]) {
+  test(`Windows selected ${agent} installs its official npm package`, options, t => {
+    const result = run(t, { args: `-AgentCommand ${agent}` });
+    pass(result);
+    assert.ok(result.calls.includes(`npm install --global ${pkg}`), `${pkg} must be installed`);
+    assert.doesNotMatch(result.calls, /Anthropic.ClaudeCode/);
+  });
+}
+
+test('Windows npm agent installation failure is not reported as ready', options, t => {
+  const result = run(t, { args: '-AgentCommand codex', fail: '@openai/codex' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /47/);
+});
+
+test('Windows none selection does not require an agent CLI', options, t => {
+  const result = run(t, { tools: ['node', 'npm', 'git'], args: '-AgentCommand none' });
+  pass(result);
+  assert.doesNotMatch(result.calls, /winget |npm install/);
+});
+
+test('Windows plugin build installs and selects the JDK17 toolchain', options, t => {
+  const result = run(t, { args: '-WithPlugin' });
+  pass(result);
+  assert.match(result.calls, /EclipseAdoptium.Temurin.17.JDK/);
+  assert.equal(readFileSync(path.join(result.dir, 'java-home.txt'), 'utf8').trim(), path.join(result.dir, 'programfiles/Eclipse Adoptium/jdk-17.0.19'));
+});
+
+test('Windows existing JDK17 is reused and no-plugin mode does not install Java', options, t => {
+  const result = run(t, { args: '-WithPlugin', jdk: true });
+  pass(result);
+  assert.doesNotMatch(result.calls, /EclipseAdoptium/);
+  assert.equal(existsSync(path.join(result.dir, 'java-home.txt')), true);
+});

--- a/scripts/tests/install-dependencies-windows.test.mjs
+++ b/scripts/tests/install-dependencies-windows.test.mjs
@@ -2,7 +2,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,15 +11,22 @@ const helper = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../in
 const options = { skip: process.platform !== 'win32' };
 const quote = value => `'${value.replaceAll("'", "''")}'`;
 
-function run(t, { tools = ['node', 'npm', 'git', 'claude', 'winget'], nodeVersion = 'v24.13.0', args = '', fail = '', jdk = false } = {}) {
+function run(t, { tools = ['node', 'npm', 'git', 'claude', 'winget'], nodeVersion = 'v24.13.0', args = '', fail = '', jdk = false, ambientJdk = false } = {}) {
   const dir = mkdtempSync(path.join(tmpdir(), 'moe deps test '));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   for (const folder of ['profile', 'appdata', 'localappdata', 'programfiles', 'bin']) mkdirSync(path.join(dir, folder));
+  const ambientJava = path.join(dir, 'ambient-java');
+  if (ambientJdk) {
+    mkdirSync(path.join(ambientJava, 'bin'), { recursive: true });
+    writeFileSync(path.join(ambientJava, 'release'), 'JAVA_VERSION="17.0.99"\n');
+    for (const name of ['java.exe', 'javac.exe']) writeFileSync(path.join(ambientJava, 'bin', name), 'fixture');
+  }
   const runner = path.join(dir, 'runner.ps1');
   writeFileSync(runner, `
 $ErrorActionPreference = 'Stop'
 $env:ProgramFiles = ${quote(path.join(dir, 'programfiles'))}
 $env:JAVA_HOME = ''
+${ambientJdk ? `$env:Path = ${quote(path.join(ambientJava, 'bin'))} + ';' + $env:Path` : ''}
 $env:Path = ${quote(path.join(dir, 'version-manager'))} + ';' + $env:Path
 $global:availableTools = @(${tools.map(quote).join(', ')})
 $global:nodeVersion = ${quote(nodeVersion)}
@@ -28,7 +35,8 @@ $global:logFile = ${quote(path.join(dir, 'calls.txt'))}
 Set-Content -LiteralPath $global:logFile -Value ''
 function Get-Command {
     param([string]$Name, $ErrorAction)
-    if ($Name -in @('node', 'npm', 'git', 'claude', 'codex', 'gemini', 'grok', 'winget')) {
+    # Hosted runners can expose JDK17 through PATH even with JAVA_HOME cleared.
+    if ($Name -in @('node', 'npm', 'git', 'claude', 'codex', 'gemini', 'grok', 'winget', 'javac')) {
         if ($Name -in $global:availableTools) { return [pscustomobject]@{ Name = $Name; Source = $Name } }
         return $null
     }
@@ -87,6 +95,13 @@ $env:Path | Set-Content -LiteralPath ${quote(path.join(dir, 'runtime-path.txt'))
 }
 
 function pass(result) { assert.equal(result.status, 0, result.stdout + result.stderr); }
+
+function assertSelectedJdk(result) {
+  const selected = readFileSync(path.join(result.dir, 'java-home.txt'), 'utf8').trim();
+  const expected = path.join(result.dir, 'programfiles/Eclipse Adoptium/jdk-17.0.19');
+  // PowerShell may return a long path when the fixture's TEMP uses an 8.3 alias.
+  assert.equal(realpathSync.native(selected), realpathSync.native(expected));
+}
 
 test('Windows ready dependencies do not invoke package installation', options, t => {
   const result = run(t);
@@ -161,7 +176,7 @@ test('Windows plugin build installs and selects the JDK17 toolchain', options, t
   const result = run(t, { args: '-WithPlugin' });
   pass(result);
   assert.match(result.calls, /EclipseAdoptium.Temurin.17.JDK/);
-  assert.equal(readFileSync(path.join(result.dir, 'java-home.txt'), 'utf8').trim(), path.join(result.dir, 'programfiles/Eclipse Adoptium/jdk-17.0.19'));
+  assertSelectedJdk(result);
 });
 
 test('Windows existing JDK17 is reused and no-plugin mode does not install Java', options, t => {
@@ -169,4 +184,11 @@ test('Windows existing JDK17 is reused and no-plugin mode does not install Java'
   pass(result);
   assert.doesNotMatch(result.calls, /EclipseAdoptium/);
   assert.equal(existsSync(path.join(result.dir, 'java-home.txt')), true);
+});
+
+test('Windows dependency fixtures ignore an ambient JDK on the inherited PATH', options, t => {
+  const result = run(t, { args: '-WithPlugin', ambientJdk: true });
+  pass(result);
+  assert.match(result.calls, /EclipseAdoptium.Temurin.17.JDK/);
+  assertSelectedJdk(result);
 });

--- a/scripts/tests/installers.test.mjs
+++ b/scripts/tests/installers.test.mjs
@@ -1,0 +1,239 @@
+// Isolated installer regressions: npm/Gradle are fake and all profile writes stay in fixtures.
+// Run: node --test scripts/tests/installers.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, cpSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const isWindows = process.platform === 'win32';
+const bash = isWindows ? 'C:/Program Files/Git/bin/bash.exe' : 'bash';
+const shellPath = value => isWindows ? value.replaceAll('\\', '/').replace(/^([A-Z]):/i, (_, drive) => `/${drive.toLowerCase()}`) : value;
+const psQuote = value => `'${value.replaceAll("'", "''")}'`;
+
+function fixture(t) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'moe installer test '));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  for (const name of ['scripts', 'packages/moe-daemon', 'packages/moe-proxy', 'moe-jetbrains', 'profile', 'appdata', 'temp', 'bin']) {
+    mkdirSync(path.join(dir, name), { recursive: true });
+  }
+  for (const file of ['install-all.ps1', 'install-all.sh', 'install-mac.sh']) {
+    cpSync(path.join(root, 'scripts', file), path.join(dir, 'scripts', file));
+  }
+  writeFileSync(path.join(dir, 'packages/moe-daemon/package.json'), JSON.stringify({ version: '9.8.7' }));
+  writeFileSync(path.join(dir, 'scripts/doctor.sh'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+  writeFileSync(path.join(dir, 'scripts/install-dependencies.sh'), 'moe_install_dependencies() { :; }\n');
+  writeFileSync(path.join(dir, 'scripts/install-dependencies.ps1'), "param([switch]$WithPlugin, [string]$AgentCommand)\nSet-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'dependency-args.txt') -Value ($AgentCommand + '|' + $WithPlugin.IsPresent)\n");
+  writeFileSync(path.join(dir, 'bin/npm'), '#!/usr/bin/env bash\nprintf "%s|%s\\n" "$PWD" "$*" >> "$MOE_TEST_NPM_LOG"\n', { mode: 0o755 });
+  return dir;
+}
+
+function runPowerShell(dir, args = '', setup = '', failCommand = '') {
+  const runner = path.join(dir, 'run.ps1');
+  writeFileSync(runner, `
+$ErrorActionPreference = 'Stop'
+function npm {
+    Add-Content -LiteralPath $env:MOE_TEST_NPM_LOG -Value ((Get-Location).Path + '|' + ($args -join ' '))
+    $global:LASTEXITCODE = if (($args -join ' ') -eq ${psQuote(failCommand)}) { 37 } else { 0 }
+}
+${setup}
+Set-Location -LiteralPath ${psQuote(dir)}
+try {
+    & ${psQuote(path.join(dir, 'scripts/install-all.ps1'))} ${args}
+} finally {
+    (Get-Location).Path | Set-Content -LiteralPath ${psQuote(path.join(dir, 'final-cwd.txt'))}
+}
+`);
+  return spawnSync('powershell.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-File', runner], {
+    encoding: 'utf8', timeout: 30000,
+    env: { ...process.env, USERPROFILE: path.join(dir, 'profile'), APPDATA: path.join(dir, 'appdata'), TEMP: path.join(dir, 'temp'), MOE_TEST_NPM_LOG: path.join(dir, 'npm.log') },
+  });
+}
+
+function runBash(dir, script, args = []) {
+  return spawnSync(bash, [shellPath(path.join(dir, 'scripts', script)), ...args], {
+    cwd: dir, encoding: 'utf8', timeout: 30000,
+    env: { ...process.env, HOME: shellPath(path.join(dir, 'profile')), PATH: `${path.join(dir, 'bin')}${path.delimiter}${process.env.PATH}`, MOE_TEST_NPM_LOG: shellPath(path.join(dir, 'npm.log')) },
+  });
+}
+
+function succeeded(result) {
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+}
+
+test('Windows default installation succeeds without a JetBrains IDE', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir));
+  assert.equal(existsSync(path.join(dir, 'profile/.moe/config.json')), true, 'default install must finish and write config without an IDE');
+  assert.equal(JSON.parse(readFileSync(path.join(dir, 'profile/.moe/config.json'), 'utf8').replace(/^\uFEFF/, '')).version, '9.8.7');
+});
+
+test('Windows installer automatically bootstraps its default agent dependencies', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir));
+  assert.equal(existsSync(path.join(dir, 'dependency-args.txt')), true, 'installer must invoke dependency bootstrap');
+  assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'claude|False');
+});
+
+test('Windows dependency failure stops before npm builds', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  writeFileSync(path.join(dir, 'scripts/install-dependencies.ps1'), "throw 'Dependency bootstrap failed'\n");
+  const result = runPowerShell(dir);
+  assert.notEqual(result.status, 0);
+  assert.equal(existsSync(path.join(dir, 'npm.log')), false);
+});
+
+test('Windows plugin archive install passes agent choice and skips JDK bootstrap', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir, '-AgentCommand codex -InstallPlugin -PluginZip ./plugin.zip', pluginSetup(dir)));
+  assert.equal(existsSync(path.join(dir, 'dependency-args.txt')), true, 'installer must pass dependency choices to bootstrap');
+  assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'codex|False');
+});
+
+test('Windows build-only option provisions JDK and produces an archive without an IDE', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  writeFileSync(path.join(dir, 'moe-jetbrains/gradlew.bat'), '@echo Simulated Gradle build output\r\n@exit /b 0\r\n');
+  const setup = `
+$payload = ${psQuote(path.join(dir, 'payload/moe-jetbrains/lib'))}
+New-Item -ItemType Directory -Path $payload -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $payload 'plugin.jar') -Value 'fixture'
+New-Item -ItemType Directory -Path ${psQuote(path.join(dir, 'moe-jetbrains/build/distributions'))} -Force | Out-Null
+Compress-Archive -Path ${psQuote(path.join(dir, 'payload/moe-jetbrains'))} -DestinationPath ${psQuote(path.join(dir, 'moe-jetbrains/build/distributions/moe.zip'))}
+`;
+  const result = runPowerShell(dir, '-BuildPlugin -AgentCommand none', setup);
+  succeeded(result);
+  assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'none|True');
+  assert.ok(result.stdout.includes(path.join(dir, 'moe-jetbrains/build/distributions/moe.zip')));
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains')), false);
+});
+
+test('Windows installation registers both CLI commands and restores caller directory', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir, '-InstallPlugin:$false'));
+  const calls = readFileSync(path.join(dir, 'npm.log'), 'utf8').trim().split(/\r?\n/);
+  assert.equal(calls.filter(line => line.endsWith('|link')).length, 2, 'daemon and proxy must each be linked');
+  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+});
+
+test('Windows installation restores caller directory', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir, '-InstallPlugin:$false'));
+  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+});
+
+test('Windows global config is portable UTF-8 JSON without a BOM', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir));
+  const configText = readFileSync(path.join(dir, 'profile/.moe/config.json'), 'utf8');
+  assert.equal(configText.charCodeAt(0), '{'.charCodeAt(0), 'Node and Python JSON readers reject the PowerShell UTF-8 BOM');
+  assert.equal(JSON.parse(configText).installPath, dir);
+});
+
+test('Windows failed CLI registration aborts with caller directory restored', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  const result = runPowerShell(dir, '-InstallPlugin:$false', '', 'link');
+  assert.notEqual(result.status, 0, 'npm link failure must fail installation');
+  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  assert.equal(existsSync(path.join(dir, 'profile/.moe/config.json')), false);
+});
+
+function pluginSetup(dir, ide = 'IntelliJIdea2026.2') {
+  return `
+$pluginDir = ${psQuote(path.join(dir, 'appdata/JetBrains', ide, 'plugins/moe-jetbrains/lib'))}
+New-Item -ItemType Directory -Path $pluginDir -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $pluginDir 'existing.txt') -Value 'existing'
+$payload = ${psQuote(path.join(dir, 'payload/moe-jetbrains/lib'))}
+New-Item -ItemType Directory -Path $payload -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $payload 'new.txt') -Value 'new'
+Compress-Archive -Path ${psQuote(path.join(dir, 'payload/moe-jetbrains'))} -DestinationPath ${psQuote(path.join(dir, 'plugin.zip'))}
+`;
+}
+
+test('Windows explicit plugin install supports a detected IntelliJ IDE and relative ZIP', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir, '-InstallPlugin -PluginZip ./plugin.zip', pluginSetup(dir)));
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/IntelliJIdea2026.2/plugins/moe-jetbrains/lib/new.txt')), true);
+});
+
+test('Windows Gradle failure never installs a stale plugin ZIP', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  writeFileSync(path.join(dir, 'moe-jetbrains/gradlew.bat'), '@exit /b 42\r\n');
+  const setup = `${pluginSetup(dir, 'PyCharm2025.2')}
+New-Item -ItemType Directory -Path ${psQuote(path.join(dir, 'moe-jetbrains/build/distributions'))} -Force | Out-Null
+Copy-Item -LiteralPath ${psQuote(path.join(dir, 'plugin.zip'))} -Destination ${psQuote(path.join(dir, 'moe-jetbrains/build/distributions/stale.zip'))}
+`;
+  const result = runPowerShell(dir, '-InstallPlugin', setup);
+  assert.notEqual(result.status, 0, 'failed Gradle must abort even if an old distribution exists');
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/PyCharm2025.2/plugins/moe-jetbrains/lib/existing.txt')), true);
+  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'claude|True');
+});
+
+test('Windows malformed plugin ZIP preserves the installed plugin', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  const setup = `${pluginSetup(dir, 'PyCharm2025.2')}
+Set-Content -LiteralPath ${psQuote(path.join(dir, 'bad.txt'))} -Value 'invalid plugin'
+Compress-Archive -LiteralPath ${psQuote(path.join(dir, 'bad.txt'))} -DestinationPath ${psQuote(path.join(dir, 'bad.zip'))}
+`;
+  const result = runPowerShell(dir, '-InstallPlugin -PluginZip ' + psQuote(path.join(dir, 'bad.zip')), setup);
+  assert.notEqual(result.status, 0);
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/PyCharm2025.2/plugins/moe-jetbrains/lib/existing.txt')), true);
+});
+
+test('Windows replacement failure restores the previous plugin backup', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  const setup = `${pluginSetup(dir)}
+function Move-Item {
+    param([string]$LiteralPath, [string]$Destination)
+    if ($LiteralPath -like '*moe-jetbrains-install-*') { throw 'simulated replacement failure' }
+    Microsoft.PowerShell.Management\\Move-Item -LiteralPath $LiteralPath -Destination $Destination
+}
+`;
+  const result = runPowerShell(dir, '-InstallPlugin -PluginZip ./plugin.zip', setup);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /simulated replacement failure/);
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/IntelliJIdea2026.2/plugins/moe-jetbrains/lib/existing.txt')), true);
+});
+
+test('Windows legacy PyCharmVersion option still selects its IDE', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  succeeded(runPowerShell(dir, '-InstallPlugin -PyCharmVersion PyCharm2025.2 -PluginZip ./plugin.zip', pluginSetup(dir, 'PyCharm2025.2')));
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/PyCharm2025.2/plugins/moe-jetbrains/lib/new.txt')), true);
+});
+
+test('Windows IDE selection rejects parent traversal', { skip: !isWindows }, t => {
+  const dir = fixture(t);
+  const result = runPowerShell(dir, '-InstallPlugin -IdeVersion ../outside -PluginZip ./plugin.zip', pluginSetup(dir));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must be a JetBrains config folder name/);
+  assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/IntelliJIdea2026.2/plugins/moe-jetbrains/lib/existing.txt')), true);
+});
+
+for (const script of ['install-all.sh', 'install-mac.sh']) {
+  test(`${script} writes the installed package version using Node only`, { skip: isWindows && !existsSync(bash) }, t => {
+    const dir = fixture(t);
+    writeFileSync(path.join(dir, 'bin/python3'), '#!/usr/bin/env bash\necho "Unexpected Python dependency" >&2\nexit 91\n', { mode: 0o755 });
+    succeeded(runBash(dir, script, script === 'install-mac.sh' ? ['--skip-mcp'] : []));
+    const config = JSON.parse(readFileSync(path.join(dir, 'profile/.moe/config.json'), 'utf8'));
+    assert.equal(config.version, '9.8.7');
+  });
+}
+
+test('Mac local MCP command separates executable from its path argument', { skip: isWindows && !existsSync(bash) }, t => {
+  const dir = fixture(t);
+  succeeded(runBash(dir, 'install-mac.sh'));
+  const config = JSON.parse(readFileSync(path.join(dir, 'profile/.config/claude/mcp_servers.json'), 'utf8'));
+  assert.equal(config.moe.command, 'node');
+  assert.equal(config.moe.args.length, 1);
+  assert.match(config.moe.args[0], /packages\/moe-proxy\/dist\/index\.js$/);
+});
+
+test('Mac explicit global installation registers both CLI commands', { skip: isWindows && !existsSync(bash) }, t => {
+  const dir = fixture(t);
+  succeeded(runBash(dir, 'install-mac.sh', ['--global', '--skip-mcp']));
+  const calls = readFileSync(path.join(dir, 'npm.log'), 'utf8').trim().split(/\r?\n/);
+  assert.equal(calls.filter(line => line.endsWith('|link')).length, 2);
+});

--- a/scripts/tests/installers.test.mjs
+++ b/scripts/tests/installers.test.mjs
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, cpSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, cpSync, existsSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -64,6 +64,11 @@ function succeeded(result) {
   assert.equal(result.status, 0, result.stdout + result.stderr);
 }
 
+function samePath(actual, expected) {
+  // PowerShell expands Windows 8.3 aliases in Get-Location and FullName.
+  assert.equal(realpathSync.native(actual), realpathSync.native(expected));
+}
+
 test('Windows default installation succeeds without a JetBrains IDE', { skip: !isWindows }, t => {
   const dir = fixture(t);
   succeeded(runPowerShell(dir));
@@ -106,7 +111,9 @@ Compress-Archive -Path ${psQuote(path.join(dir, 'payload/moe-jetbrains'))} -Dest
   const result = runPowerShell(dir, '-BuildPlugin -AgentCommand none', setup);
   succeeded(result);
   assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'none|True');
-  assert.ok(result.stdout.includes(path.join(dir, 'moe-jetbrains/build/distributions/moe.zip')));
+  const archive = result.stdout.match(/^Plugin archive: (.+)$/m);
+  assert.ok(archive, result.stdout);
+  samePath(archive[1].trim(), path.join(dir, 'moe-jetbrains/build/distributions/moe.zip'));
   assert.equal(existsSync(path.join(dir, 'appdata/JetBrains')), false);
 });
 
@@ -115,13 +122,13 @@ test('Windows installation registers both CLI commands and restores caller direc
   succeeded(runPowerShell(dir, '-InstallPlugin:$false'));
   const calls = readFileSync(path.join(dir, 'npm.log'), 'utf8').trim().split(/\r?\n/);
   assert.equal(calls.filter(line => line.endsWith('|link')).length, 2, 'daemon and proxy must each be linked');
-  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  samePath(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
 });
 
 test('Windows installation restores caller directory', { skip: !isWindows }, t => {
   const dir = fixture(t);
   succeeded(runPowerShell(dir, '-InstallPlugin:$false'));
-  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  samePath(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
 });
 
 test('Windows global config is portable UTF-8 JSON without a BOM', { skip: !isWindows }, t => {
@@ -129,14 +136,14 @@ test('Windows global config is portable UTF-8 JSON without a BOM', { skip: !isWi
   succeeded(runPowerShell(dir));
   const configText = readFileSync(path.join(dir, 'profile/.moe/config.json'), 'utf8');
   assert.equal(configText.charCodeAt(0), '{'.charCodeAt(0), 'Node and Python JSON readers reject the PowerShell UTF-8 BOM');
-  assert.equal(JSON.parse(configText).installPath, dir);
+  samePath(JSON.parse(configText).installPath, dir);
 });
 
 test('Windows failed CLI registration aborts with caller directory restored', { skip: !isWindows }, t => {
   const dir = fixture(t);
   const result = runPowerShell(dir, '-InstallPlugin:$false', '', 'link');
   assert.notEqual(result.status, 0, 'npm link failure must fail installation');
-  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  samePath(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
   assert.equal(existsSync(path.join(dir, 'profile/.moe/config.json')), false);
 });
 
@@ -168,7 +175,7 @@ Copy-Item -LiteralPath ${psQuote(path.join(dir, 'plugin.zip'))} -Destination ${p
   const result = runPowerShell(dir, '-InstallPlugin', setup);
   assert.notEqual(result.status, 0, 'failed Gradle must abort even if an old distribution exists');
   assert.equal(existsSync(path.join(dir, 'appdata/JetBrains/PyCharm2025.2/plugins/moe-jetbrains/lib/existing.txt')), true);
-  assert.equal(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
+  samePath(readFileSync(path.join(dir, 'final-cwd.txt'), 'utf8').trim(), dir);
   assert.equal(readFileSync(path.join(dir, 'dependency-args.txt'), 'utf8').trim(), 'claude|True');
 });
 

--- a/scripts/tests/onboarding.mjs
+++ b/scripts/tests/onboarding.mjs
@@ -1,0 +1,194 @@
+// Real built daemon + MCP proxy, fresh project, no agent account or IDE required.
+// First build packages/moe-daemon and packages/moe-proxy, then run:
+// node scripts/tests/onboarding.mjs [extracted IDE bundle directory]
+import assert from 'node:assert/strict';
+import { spawn, execFileSync } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const bundle = process.argv[2] && path.resolve(process.argv[2]);
+const daemonEntry = bundle ? path.join(bundle, 'daemon/index.js') : path.join(root, 'packages/moe-daemon/dist/index.js');
+const proxyEntry = bundle ? path.join(bundle, 'proxy/index.js') : path.join(root, 'packages/moe-proxy/dist/index.js');
+const manifest = bundle ? path.join(bundle, 'daemon/package.json') : path.join(root, 'packages/moe-daemon/package.json');
+const expectedVersion = JSON.parse(fs.readFileSync(manifest, 'utf8')).version;
+assert.ok(fs.existsSync(daemonEntry), 'Build moe-daemon first');
+assert.ok(fs.existsSync(proxyEntry), 'Build moe-proxy first');
+const require = createRequire(proxyEntry);
+const WebSocket = require('ws');
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-onboarding-'));
+const project = path.join(scratch, 'project with spaces');
+const profile = path.join(scratch, 'profile');
+fs.mkdirSync(project);
+fs.mkdirSync(profile);
+const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('MOE_')));
+Object.assign(env, { HOME: profile, USERPROFILE: profile, NODE_ENV: 'production', LOG_LEVEL: 'silent' });
+let daemon;
+let proxy;
+let board;
+
+async function until(check, label) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const value = await check();
+    if (value) return value;
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+
+async function start() {
+  const listener = net.createServer();
+  listener.listen(0, '127.0.0.1');
+  await once(listener, 'listening');
+  const port = listener.address().port;
+  await new Promise(resolve => listener.close(resolve));
+  daemon = spawn(process.execPath, [daemonEntry, 'init', '--project', project, '--port', String(port)],
+    { env, windowsHide: true, stdio: 'ignore' });
+  let spawnError;
+  daemon.once('error', error => { spawnError = error; });
+  return until(async () => {
+    if (spawnError) throw spawnError;
+    assert.equal(daemon.exitCode, null, 'Daemon exited before becoming healthy');
+    const infoPath = path.join(project, '.moe/daemon.json');
+    if (!fs.existsSync(infoPath)) return false;
+    let info;
+    try { info = JSON.parse(fs.readFileSync(infoPath, 'utf8')); } catch { return false; }
+    assert.equal(path.resolve(info.projectPath), project);
+    let response;
+    try { response = await fetch(`http://127.0.0.1:${info.port}/health`, { signal: AbortSignal.timeout(1000) }); }
+    catch { return false; }
+    if (!response.ok) return false;
+    const health = await response.json();
+    assert.equal(health.version, expectedVersion, 'Health must report the installed package version');
+    return info;
+  }, 'fresh daemon health');
+}
+
+function connectProxy() {
+  proxy = spawn(process.execPath, [proxyEntry], {
+    env: { ...env, MOE_PROJECT_PATH: project }, windowsHide: true, stdio: ['pipe', 'pipe', 'ignore'],
+  });
+  let sequence = 0;
+  let proxyFailure;
+  const pending = new Map();
+  createInterface({ input: proxy.stdout }).on('line', line => {
+    let message;
+    try { message = JSON.parse(line); } catch (error) { fail(error); return; }
+    const request = pending.get(message.id);
+    if (!request) return;
+    pending.delete(message.id);
+    clearTimeout(request.timer);
+    if (message.error) request.reject(new Error(JSON.stringify(message.error)));
+    else request.resolve(message.result);
+  });
+  const fail = error => {
+    proxyFailure = error;
+    for (const request of pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(error);
+    }
+    pending.clear();
+  };
+  proxy.on('error', fail);
+  proxy.on('exit', code => fail(new Error(`Proxy exited: ${code}`)));
+  return (method, params = {}) => new Promise((resolve, reject) => {
+    if (proxyFailure) { reject(proxyFailure); return; }
+    const id = ++sequence;
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`MCP timeout: ${method}`));
+    }, 15_000);
+    pending.set(id, { resolve, reject, timer });
+    proxy.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+  });
+}
+
+async function stop() {
+  if (board) { board.terminate(); board = undefined; }
+  try {
+    if (proxy) {
+      const current = proxy;
+      proxy = undefined;
+      if (current.exitCode === null && current.signalCode === null) {
+        current.kill();
+        await until(() => current.exitCode !== null || current.signalCode !== null, 'proxy stop');
+      }
+    }
+  } finally {
+    if (daemon && daemon.exitCode === null && daemon.signalCode === null) {
+      execFileSync(process.execPath, [daemonEntry, 'stop', '--project', project],
+        { env, windowsHide: true, timeout: 15_000, stdio: 'pipe' });
+      await until(() => daemon.exitCode !== null || daemon.signalCode !== null, 'supervisor stop');
+    }
+  }
+}
+
+try {
+  const info = await start();
+  const rpc = connectProxy();
+  const initialized = await rpc('initialize', {
+    protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'onboarding-smoke', version: '1.0.0' },
+  });
+  assert.ok(initialized.serverInfo.name);
+  assert.equal(initialized.serverInfo.version, expectedVersion, 'MCP must report the installed package version');
+  if (!bundle) {
+    const configPath = path.join(profile, '.moe/config.json');
+    assert.ok(fs.existsSync(configPath), 'Source initialization must register this installation');
+    assert.equal(JSON.parse(fs.readFileSync(configPath, 'utf8')).version, expectedVersion);
+  }
+  const tools = await rpc('tools/list');
+  assert.ok(tools.tools.some(tool => tool.name === 'moe.create_task'));
+  const call = async (name, args = {}) => {
+    const result = await rpc('tools/call', { name: `moe.${name}`, arguments: args });
+    assert.ok(!result.isError, `Tool failed: ${name}`);
+    return JSON.parse(result.content.find(item => item.type === 'text').text);
+  };
+  const { epic } = await call('create_epic', { title: 'First project' });
+  const { task } = await call('create_task', {
+    epicId: epic.id, title: 'Document the project', definitionOfDone: ['README describes the project'],
+  });
+  assert.equal(task.status, 'BACKLOG');
+  await call('set_task_status', { taskId: task.id, status: 'PLANNING' });
+  const { team } = await call('create_team', { name: 'First architect', role: 'architect' });
+  await call('join_team', { teamId: team.id, workerId: 'onboarding-architect' });
+  const claim = await call('claim_next_task', {
+    workerId: 'onboarding-architect', statuses: ['PLANNING'], taskId: task.id,
+  });
+  assert.equal(claim.task.id, task.id);
+  await call('get_context', { taskId: task.id, workerId: 'onboarding-architect' });
+  await call('submit_plan', { taskId: task.id, workerId: 'onboarding-architect', steps: [{
+    description: 'Write project overview', affectedFiles: ['README.md'], newFiles: ['README.md'],
+  }] });
+  let context = await call('get_context', { taskId: task.id });
+  assert.equal(context.task.status, 'AWAITING_APPROVAL', 'CONTROL must wait for approval');
+  board = new WebSocket(`ws://127.0.0.1:${info.port}/ws`);
+  await once(board, 'open');
+  board.send(JSON.stringify({ type: 'APPROVE_TASK', payload: { taskId: task.id } }));
+  await until(async () => {
+    context = await call('get_context', { taskId: task.id });
+    return context.task.status === 'WORKING';
+  }, 'board approval');
+  const doctor = execFileSync(process.execPath, [daemonEntry, 'doctor', '--project', project],
+    { env, windowsHide: true, timeout: 15_000, encoding: 'utf8' });
+  assert.ok(doctor.length > 0);
+  await stop();
+  await start();
+  const restarted = connectProxy();
+  const result = await restarted('tools/call', { name: 'moe.get_context', arguments: { taskId: task.id } });
+  const persisted = JSON.parse(result.content.find(item => item.type === 'text').text);
+  assert.equal(persisted.task.id, task.id);
+  assert.equal(persisted.task.status, 'WORKING');
+  console.log('PASS onboarding: fresh init, health, MCP, epic/task, architect claim, plan approval, doctor, restart persistence');
+} finally {
+  await stop();
+  assert.equal(path.dirname(scratch), path.resolve(os.tmpdir()));
+  assert.ok(path.basename(scratch).startsWith('moe-onboarding-'));
+  fs.rmSync(scratch, { recursive: true, force: true });
+}

--- a/scripts/tests/onboarding.mjs
+++ b/scripts/tests/onboarding.mjs
@@ -28,10 +28,14 @@ const profile = path.join(scratch, 'profile');
 fs.mkdirSync(project);
 fs.mkdirSync(profile);
 const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('MOE_')));
-Object.assign(env, { HOME: profile, USERPROFILE: profile, NODE_ENV: 'production', LOG_LEVEL: 'silent' });
+Object.assign(env, { HOME: profile, USERPROFILE: profile, NODE_ENV: 'production', LOG_LEVEL: 'warn' });
 let daemon;
 let proxy;
 let board;
+let diagnostics = '';
+function capture(stream, label) {
+  stream.on('data', chunk => { diagnostics = `${diagnostics}\n${label}: ${chunk}`.slice(-16000); });
+}
 
 async function until(check, label) {
   const deadline = Date.now() + 20_000;
@@ -50,7 +54,9 @@ async function start() {
   const port = listener.address().port;
   await new Promise(resolve => listener.close(resolve));
   daemon = spawn(process.execPath, [daemonEntry, 'init', '--project', project, '--port', String(port)],
-    { env, windowsHide: true, stdio: 'ignore' });
+    { env, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] });
+  capture(daemon.stdout, 'daemon');
+  capture(daemon.stderr, 'daemon stderr');
   let spawnError;
   daemon.once('error', error => { spawnError = error; });
   return until(async () => {
@@ -73,8 +79,9 @@ async function start() {
 
 function connectProxy() {
   proxy = spawn(process.execPath, [proxyEntry], {
-    env: { ...env, MOE_PROJECT_PATH: project }, windowsHide: true, stdio: ['pipe', 'pipe', 'ignore'],
+    env: { ...env, MOE_PROJECT_PATH: project }, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'],
   });
+  capture(proxy.stderr, 'proxy stderr');
   let sequence = 0;
   let proxyFailure;
   const pending = new Map();
@@ -85,7 +92,7 @@ function connectProxy() {
     if (!request) return;
     pending.delete(message.id);
     clearTimeout(request.timer);
-    if (message.error) request.reject(new Error(JSON.stringify(message.error)));
+    if (message.error) request.reject(new Error(`${request.label}: ${JSON.stringify(message.error)}`));
     else request.resolve(message.result);
   });
   const fail = error => {
@@ -105,7 +112,7 @@ function connectProxy() {
       pending.delete(id);
       reject(new Error(`MCP timeout: ${method}`));
     }, 15_000);
-    pending.set(id, { resolve, reject, timer });
+    pending.set(id, { resolve, reject, timer, label: params.name || method });
     proxy.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
   });
 }
@@ -186,6 +193,9 @@ try {
   assert.equal(persisted.task.id, task.id);
   assert.equal(persisted.task.status, 'WORKING');
   console.log('PASS onboarding: fresh init, health, MCP, epic/task, architect claim, plan approval, doctor, restart persistence');
+} catch (error) {
+  console.error('Fixture daemon/proxy diagnostics:', diagnostics || '(none)');
+  throw error;
 } finally {
   await stop();
   assert.equal(path.dirname(scratch), path.resolve(os.tmpdir()));

--- a/scripts/tests/release-version.mjs
+++ b/scripts/tests/release-version.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const validator = fileURLToPath(new URL('../verify-release-version.mjs', import.meta.url));
+const manifests = ['packages/moe-daemon/package.json', 'packages/moe-proxy/package.json', 'moe-vscode/package.json'];
+
+function fixture(run) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-release-version-'));
+  try {
+    for (const file of manifests) {
+      fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+      fs.writeFileSync(path.join(root, file), JSON.stringify({ version: '0.8.0' }));
+    }
+    fs.mkdirSync(path.join(root, 'moe-jetbrains'));
+    fs.writeFileSync(path.join(root, 'moe-jetbrains/build.gradle.kts'), 'version = "0.8.0"\n');
+    run(root);
+  } finally {
+    assert.equal(path.dirname(root), path.resolve(os.tmpdir()));
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('matching release tag and packaged versions pass', () => fixture(root => {
+  const output = execFileSync(process.execPath, [validator, 'v0.8.0'], { cwd: root, encoding: 'utf8' });
+  assert.match(output, /PASS release versions: 0\.8\.0/);
+}));
+
+for (const file of [...manifests, 'moe-jetbrains/build.gradle.kts']) {
+  test(`rejects mismatched ${file} before publication`, () => fixture(root => {
+    fs.writeFileSync(path.join(root, file), file.endsWith('.json') ? '{"version":"0.6.0"}' : 'version = "0.6.0"\n');
+    const result = spawnSync(process.execPath, [validator, 'v0.8.0'], { cwd: root, encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.ok(result.stderr.includes(file));
+    assert.match(result.stderr, /expected 0\.8\.0/);
+  }));
+}
+
+test('rejects missing or malformed tags', () => fixture(root => {
+  for (const tag of ['', 'latest', 'v0.8']) {
+    const result = spawnSync(process.execPath, [validator, tag], { cwd: root, encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /release tag/);
+  }
+}));

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+
+// Run from the repository root before building or publishing a tagged release.
+try {
+  const tag = process.argv[2];
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag || '')) {
+    throw new Error('Expected a release tag such as v0.8.0');
+  }
+  const expected = tag.slice(1);
+  const versions = [
+    'packages/moe-daemon/package.json',
+    'packages/moe-proxy/package.json',
+    'moe-vscode/package.json',
+  ].map(file => [file, JSON.parse(fs.readFileSync(file, 'utf8')).version]);
+  const gradle = 'moe-jetbrains/build.gradle.kts';
+  versions.push([gradle, fs.readFileSync(gradle, 'utf8').match(/^version\s*=\s*"([^"]+)"/m)?.[1]]);
+  const mismatches = versions.filter(([, version]) => version !== expected);
+  if (mismatches.length) {
+    throw new Error(mismatches.map(([file, version]) => `${file}: found ${version}, expected ${expected}`).join('\n'));
+  }
+  console.log(`PASS release versions: ${expected}`);
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Fresh source downloads could fail during dependency setup, IDE startup, or the first task, while worker launch failures could exhaust retries and leave seats idle. This change makes installers provision the supported runtime/toolchain and chosen coding CLI, fixes the first-task path, and keeps failed agent launches recoverable.

- Windows and macOS/Linux installers handle missing dependencies, preserve existing configuration, propagate setup failures, and explain provider sign-in and plugin installation.
- JetBrains can create the first epic/task and discover installer-managed Node from a GUI session. VS Code handles asynchronous startup failures and uses the same managed runtime.
- The file watcher resolves Windows short-name paths before opening native handles; first-epic creation no longer aborts the daemon. Regression verification includes ten successful repetitions under the same real 8.3 alias that crashed the baseline.
- Daemon health/MCP report the installed version; source initialization registers the installation correctly. Bundled runtime metadata works in both IDE packages.
- Worker launch failures back off without exhausting resume attempts; heartbeats cover the CLI lifetime; Codex seats receive their own instructions and worker identity; planning/blocked tasks can be archived.
- CI exercises fresh Linux dependency installation, onboarding on three operating systems, installer/runtime regressions, and the packaged JetBrains runtime. Releases validate consistent versions and both packaged onboarding flows before publishing.

Validation: daemon 1,098 tests, proxy 59 tests, JetBrains 63 tests, VS Code 7 tests plus compilation, 58 installer/dependency/release checks, and four launcher runtime checks passed locally. A clean Ubuntu container installed Node/npm/Git/Python/download tools/tmux, built Moe, completed onboarding, and installed Claude and JDK 17. An isolated Windows profile completed installation and onboarding. Both built IDE packages, including the Windows short-path regression, completed real fresh-project initialization, MCP connection, task planning/approval, doctor, and restart persistence.

Remaining verification: native macOS dependency installation and an interactive IDE/provider-sign-in task have not been exercised locally. Existing root role-doc lint fails because docs/roles/architect.md exceeds its 40-line cap; this file is unchanged. Package versions remain 0.6.0; no new release has been published.

A separate clean rehearsal merged all ten open dependency PRs without conflicts or lock regeneration. Combined builds, 1,098 daemon tests, 59 proxy tests, and fresh-project onboarding passed. The existing picomatch production fixes were preserved.

Final GitHub validation at dd6bbc11c35ea5c4ec67dd535009b0174bcda388: all eight checks passed, including fresh Linux installation, onboarding/installer tests on Windows/macOS/Linux, packaged JetBrains onboarding, TypeScript coverage, and Docker. [CI run](https://github.com/yaront1111/Moe-s-Tavern/actions/runs/34033728724).
