### PR TITLE
fix(wrapper): codex worker and qa seats default to one-shot codex exec

### DIFF
--- a/scripts/moe-agent.ps1
+++ b/scripts/moe-agent.ps1
@@ -702,7 +702,16 @@ $cmdBase = [System.IO.Path]::GetFileNameWithoutExtension($cmdForDetect)
 if ($cmdBase -eq "codex") { $cliType = "codex" }
 elseif ($cmdBase -eq "gemini") { $cliType = "gemini" }
 elseif ($cmdBase -eq "grok") { $cliType = "grok" }
-# Codex is interactive by default, but -CodexExec enables non-interactive headless mode
+# Codex follows the same role polarity as claude and grok: architect/governor
+# get the TUI, worker/qa run one-shot `codex exec` unless -Interactive is
+# passed explicitly, and -CodexExec forces exec for any role. The one-shot
+# default is load-bearing, not cosmetic: the codex TUI never exits on its own
+# and this wrapper blocks inside the CLI call for its whole lifetime, so an
+# interactive worker never reaches the post-flight -- no checkpoint or
+# completion commit, no record_commit, no session-end line. Measured
+# 2026-09-06: six codex worker seats launched without -CodexExec had been
+# alive 3-18 h with commits:[] on every row they delivered.
+if ($cliType -eq "codex" -and -not $CodexExec -and -not $Interactive) { $CodexExec = $true }
 $codexInteractive = ($cliType -eq "codex") -and (-not $CodexExec)
 # Gemini is interactive by default, but -GeminiExec enables non-interactive headless mode
 $geminiInteractive = ($cliType -eq "gemini") -and (-not $GeminiExec)

--- a/scripts/moe-agent.sh
+++ b/scripts/moe-agent.sh
@@ -381,6 +381,18 @@ elif [ "$CMD_BASE" = "gemini" ]; then
 elif [ "$CMD_BASE" = "grok" ]; then
     CLI_TYPE="grok"
 fi
+# Codex follows the same role polarity as claude and grok (see INTERACTIVE
+# below): architect/governor keep the TUI, worker/qa run one-shot `codex exec`
+# unless --interactive is passed explicitly, and --codex-exec forces exec for
+# any role. Load-bearing: the codex TUI never exits on its own, so an
+# interactive worker never reaches the post-flight -- no checkpoint or
+# completion commit, no record_commit. Measured 2026-09-06 on six codex
+# worker seats launched without --codex-exec (PS twin has the same default).
+if [ "$CLI_TYPE" = "codex" ] && [ "$CODEX_EXEC" = false ]; then
+    if [ "$INTERACTIVE_REQUESTED" = false ] || { [ -z "$INTERACTIVE_REQUESTED" ] && [ "$ROLE" != "architect" ] && [ "$ROLE" != "governor" ]; }; then
+        CODEX_EXEC=true
+    fi
+fi
 CODEX_INTERACTIVE=false
 if [ "$CLI_TYPE" = "codex" ] && [ "$CODEX_EXEC" = false ]; then
     CODEX_INTERACTIVE=true


### PR DESCRIPTION
## Why

Codex worker/QA seats never land their bytes. The wrapper (both twins) launches codex **interactive** unless `-CodexExec` / `--codex-exec` is passed, and `TerminalAgentLauncher` never passes it (the repo's own Serena memory `gotcha-codex-worker-tui-skips-wrapper-postflight` recorded this on 2026-09-02). The codex TUI never exits on its own, the wrapper blocks inside the CLI call, and the post-flight that writes the checkpoint/completion commit and calls `record_commit` never runs.

Measured 2026-09-06 on the live fleet: six codex worker seats alive 3-18 h (pids since 09:28Z and since the previous evening), `task.commits: []` on every row they delivered. Consequence today: task-e651725c's importer (`daemon-store-foundation-composition.ts`) was swept into a peer's completion commit while its untracked module `orchestrator/durable-schedule.{ts,js,test.ts}` stayed behind, so `moe/work-2026-09-04` did not compile at HEAD for an hour.

## What

Codex follows the role polarity claude and grok already use in both twins:

- architect / governor: TUI (unchanged)
- worker / qa: one-shot `codex exec` by default
- `-Interactive` / `--interactive`: explicit opt back into the TUI for any role
- `-CodexExec` / `--codex-exec`: still forces exec for any role

`scripts/moe-agent.ps1`: one guarded assignment before `$codexInteractive` is derived. `scripts/moe-agent.sh`: the same resolution, using `INTERACTIVE_REQUESTED` and `ROLE`, before `CODEX_INTERACTIVE` is derived.

## Verification

- `bash -n scripts/moe-agent.sh` clean; PowerShell `Parser::ParseFile` on the ps1: 0 errors.
- sh block probed standalone for worker / qa / architect / governor with no flag, worker with `--interactive`, architect with `--no-interactive`, architect with `--codex-exec`: exec for worker/qa and for every explicit exec/non-interactive request, TUI for architect/governor and for the explicit `--interactive`.
- ps1: `$Interactive` is already role-resolved at the top of the script (architect/governor true unless `-Interactive:$false`), so `-not $Interactive` is exactly the worker/qa (or explicitly non-interactive) case.

## Deploy note

The live fleet runs the plugin bundle copy of these scripts. Running wrappers pick a changed script up at their loop top, and a codex TUI wrapper never reaches its loop top — so after copying the scripts into the plugin's `scripts/` dir, the six live codex TUIs must be closed once (their next launch is `exec`). Follow-up worth a separate PR: the lander should refuse to land a tracked importer whose new import target is an untracked path declared on another row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
