### PR TITLE
docs: make the README clearer for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,391 +1,198 @@
-```
-                             __  __            _        _____
-                            |  \/  | ___   ___( )___   |_   _|_ ___   _____ _ __ _ __
-                            | |\/| |/ _ \ / _ \// __|    | |/ _` \ \ / / _ \ '__| '_ \
-                            | |  | | (_) |  __/ \__ \    | | (_| |\ V /  __/ |  | | | |
-                            |_|  |_|\___/ \___| |___/    |_|\__,_| \_/ \___|_|  |_| |_|
-```
+# Moe's Tavern
 
-<p align="center">
-  <strong>AI Workforce Command Center</strong><br>
-  Human oversight for AI coding agents
-</p>
+**Turn your coding agents into a team you can steer.**
 
-<p align="center">
-  <a href="https://yaront1111.github.io/Moe-s-Tavern/"><img src="https://img.shields.io/badge/website-live-brightgreen.svg" alt="Website"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://github.com/yaront1111/Moe-s-Tavern/releases"><img src="https://img.shields.io/badge/version-0.6.0-green.svg" alt="Version"></a>
-  <a href="https://github.com/yaront1111/Moe-s-Tavern/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
-  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Mac%20%7C%20Linux-lightgrey.svg" alt="Platform">
-</p>
+Run Claude Code, Codex, Gemini CLI, and Grok Build through a shared task board in your IDE. Give agents clear roles, review their plans, and follow the work through implementation and QA.
 
----
-![scale](https://github.com/user-attachments/assets/346a627f-1ed3-403b-93df-9b95ae0d5543)
+[![CI](https://github.com/yaront1111/Moe-s-Tavern/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yaront1111/Moe-s-Tavern/actions/workflows/ci.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)
 
+**[Get started](#get-started) · [See the workflow](#how-it-works) · [Features](#what-you-get) · [Documentation](#documentation)**
+
+![Moe's JetBrains board showing tasks grouped by epic across Backlog, Planning, Working, Review, and Done.](https://github.com/user-attachments/assets/cc68f17b-137f-42f3-b90c-eba0b68ba032)
+
+*One place to see what is planned, what is being built, and what needs review.*
 
 ## Why Moe?
 
-AI coding agents are powerful but need guardrails. **Moe's Tavern** provides:
+Working with several coding agents means keeping track of their tasks, context, plans, and results. Moe gives that work a shared workflow: you define the outcome, an architect proposes the approach, a worker implements it, and QA checks it against your Definition of Done.
 
-- **Visibility** - See what AI agents are doing in a Kanban board
-- **Control** - Approve or reject AI plans before code gets written
-- **Persistent Memory** - Agents learn from every task and share knowledge across sessions
-- **Self-Healing** - Daemon auto-restarts on crash with exponential backoff
-- **Traceability** - Full audit log of every action
-- **Agent Chat** - Agents communicate, coordinate, and share context in real-time
-- **Skills System** - Vendored 8-phase discipline (TDD, debugging, adversarial review, regression checks) injected into every agent session
-- **Governance Mode** - Architects can pause a running task to revise rails, then hand it back
-- **Branch Safety** - Agents are blocked from auto-committing to `main` and peel onto a dated worker branch
-- **Land on Every Exit** - Every agent session exit commits its task's own files: a completion commit on REVIEW, a `wip(task-<id>)` checkpoint otherwise, a rescue ref when a gate or commit fails — attributed per task so one agent never sweeps another's edits
-- **Flexibility** - Works with Claude, Codex, Gemini, Grok, and any MCP-compatible agent
+Start with one small task. As you add agents, the same board keeps their plans, progress, conversations, and review feedback together. Choose the coding CLI for each role and decide how much approval you want to retain.
 
-> *"Let AI do the coding, but keep humans in the loop."*
+## What you get
 
----
+| Feature | What it lets you do |
+| --- | --- |
+| **A live board inside your IDE** | Organize work into epics and tasks, inspect plans and implementation steps, and follow progress from Backlog to Done. JetBrains is the primary interface; a VS Code / Antigravity extension is also included. |
+| **Plan approval before implementation** | Review proposed steps and affected files in the default **CONTROL** mode. Choose SPEED or TURBO when you want more automation. |
+| **Agents with distinct jobs** | Give planning, implementation, and QA their own roles. Add a governor to help monitor the team and surface blockers. |
+| **Your choice of coding CLI** | Launch Claude Code, Codex, Gemini CLI, or Grok Build. Pick different providers for different roles. |
+| **Coordination for parallel work** | Use teams, task dependencies, chat channels, and @mentions to coordinate agents. File overlap warnings help flag potential collisions. |
+| **Context that survives a session** | Keep tasks, plans, decisions, and handoffs with your project. Add [Serena](docs/MEMORY.md) for shared agent memory across sessions. |
+| **Git history tied to tasks** | Agent launchers create task-linked commits, checkpoints, and recovery refs so you can inspect what landed and investigate interrupted work. |
+| **Project rules and reusable practices** | Configure project rules (rails) and role guidance. Bundled skills cover planning, testing, debugging, and review; global required and forbidden patterns are checked in submitted plans. |
 
-## Features
+Moe's daemon and project state run locally, with workflow data stored in `.moe/`. Your coding agents still use their configured providers and accounts. Moe is MIT licensed; provider access and usage are separate.
 
-| Feature | Description |
-|---------|-------------|
-| **Kanban Board** | Visual task management in your IDE (JetBrains + VS Code) |
-| **Plan Approval** | Review AI implementation plans before execution |
-| **Persistent Memory** | Cross-session memory via the Serena MCP server — agents read prior knowledge on task start and write handoff/learning notes before finishing ([details](docs/MEMORY.md)) |
-| **Skills System** | 11 vendored skills (planning, TDD, systematic-debugging, adversarial-self-review, regression-check, receiving-code-review, …) auto-loaded per role ([manifest](docs/skills/manifest.json)) |
-| **Dedicated Governor** | A fourth, always-on agent role that watches for stale workers, drift, QA rejection loops, and human escalations — separate from planning, so the architect stays focused |
-| **Branch Safety** | Wrapper post-flight refuses to commit on `main`/`master` and peels onto `moe/work-<date>` automatically |
-| **Land on Every Exit** | The wrapper commits a task's own files on every session exit (completion on REVIEW, `wip` checkpoint otherwise, `refs/moe/rescue/` on failure) with tiered per-task attribution; every landing is recorded on the task and `qa_approve` audits it |
-| **Self-Healing Daemon** | Supervisor auto-restarts on crash with exponential backoff |
-| **Runtime-Driven Workflow** | Per-task agent respawn, streaming output, trimmed prompts — long sessions stay responsive |
-| **Agent Chat** | Real-time messaging with @mentions, channels, and a Mention Response Protocol that forces tagged agents to reply |
-| **Multi-Agent** | Architect, worker, QA, and governor roles across Claude, Codex, Gemini, Grok, and any MCP-compatible agent |
-| **MCP Protocol** | 40+ tools including `release_task`, `enter_governance`, `list_workers`, `propose_rail`, chat, teams (memory is provided by the Serena MCP server) |
-| **Real-time Sync** | Live updates via WebSocket |
-| **Activity Log** | Complete audit trail with log rotation |
-| **Rails System** | Forbidden / required patterns enforced on plans; architects can `propose_rail` for human review |
-| **Teams** | Launch parallel agent teams within epics |
+## How it works
 
----
-<img width="1488" height="833" alt="Screenshot 2026-02-05 011749" src="https://github.com/user-attachments/assets/cc68f17b-137f-42f3-b90c-eba0b68ba032" />
+In the default **CONTROL** mode:
 
-## Quick Start
+```mermaid
+flowchart LR
+    Task[You define a task] --> Plan[Architect proposes a plan]
+    Plan --> Approve[You review and approve]
+    Approve --> Build[Worker implements]
+    Build --> Review[QA checks the result]
+    Review --> Done[Done]
+    Review -->|Changes requested| Build
+```
 
-Start with one small task in a Git project. This walkthrough builds Moe from source and uses the **JetBrains board** to create tasks and approve plans. Follow the [first-task guide](docs/GETTING_STARTED.md) for every step, checks, and fixes for common setup problems.
+| Role | Job |
+| --- | --- |
+| **Architect** | Explore the project and propose an implementation plan. |
+| **Worker** | Implement the approved plan and record verification results. |
+| **QA** | Review the result against the Definition of Done; approve it or request changes. |
+| **Governor** | Monitor team activity, help resolve coordination problems, and escalate blockers. |
 
-### 1. Download Moe
+For a first task, ask Moe to document your project's setup and test commands. Review the architect's proposed scope, let the worker write the guide, then inspect QA's findings and the Git diff. Use the same workflow for features, bug fixes, and refactors.
 
-Download the [source ZIP](https://github.com/yaront1111/Moe-s-Tavern/archive/refs/heads/main.zip), extract it, and open a terminal in the extracted Moe folder. You can also clone the repository if Git is already installed.
+## Get started
 
-Use a JetBrains IDE for the board. Automatic dependency installation supports **Windows with WinGet**, **macOS with Homebrew and Command Line Tools**, and **Linux with apt-get or dnf**. System package installation may ask for your operating system password or permission.
+The first-run path below uses **JetBrains and one small task**. The [full walkthrough](docs/GETTING_STARTED.md) includes platform details and troubleshooting.
 
-### 2. Install Moe from source
+### 1. Download and install
 
-Run one command below. The installer handles missing Node.js/npm, Git, the selected coding CLI, and JDK 17, then builds Moe and the board plugin. On macOS/Linux it also installs Python3 and download tools; Linux includes tmux for terminal-based teams. Keep this folder: the agent launch scripts live here.
+Download the [source ZIP](https://github.com/yaront1111/Moe-s-Tavern/archive/refs/heads/main.zip), extract it, and open a terminal in the extracted Moe folder. You can also clone this repository.
 
-**Windows (PowerShell):**
+**Windows — PowerShell:**
+
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-all.ps1 -BuildPlugin
 ```
 
-**macOS / Linux (Bash):**
+**macOS / Linux:**
+
 ```bash
 bash scripts/install-mac.sh --global --skip-mcp --with-plugin
 ```
 
-Claude Code is the default. To install Codex instead, add `-AgentCommand codex` on Windows or `--agent codex` on macOS/Linux; `gemini` and `none` are also available. Open a new terminal after installation and run your selected CLI once in your target project to sign in. Moe cannot sign in to your provider account for you.
+The installer sets up Git, Node.js/npm, package dependencies, the daemon and proxy, the selected agent CLI, and JDK 17 for the plugin build. It also builds the JetBrains plugin ZIP. On Linux, it installs tmux for agent terminals. Existing compatible dependencies are reused.
 
-In your IDE, open **Settings / Preferences → Plugins → gear icon → Install Plugin from Disk**, select the ZIP in `moe-jetbrains/build/distributions/`, and restart. Use this freshly built plugin; published release downloads may contain an older implementation. See the [first-task guide](docs/GETTING_STARTED.md) if installation reports a missing package manager or PATH problem.
+You need a JetBrains IDE and your platform's package manager: **WinGet on Windows**, **Homebrew and Xcode Command Line Tools on macOS**, or **apt/dnf on Linux**. The script may request administrator access when installing system packages. If a prerequisite cannot be installed, it stops with instructions.
 
-### 3. Open your project and create a task
+**Claude Code is the default.** To choose another bootstrap option, append the corresponding flag:
 
-1. Open **your target Git project** in JetBrains and open the **Moe** tool window. The plugin initializes `.moe/` and starts the daemon. Wait for **Connected**.
-2. Open **Project Settings** and keep **Approval Mode: CONTROL** so you review the plan before implementation.
-3. Click **+ Epic**, create an epic such as `First task`, then use the **+** in its **Backlog** column to create a task. Give it a clear title, description, and Definition of Done. For example: add a `GETTING_STARTED.md` containing the project's verified setup and test commands.
-4. Drag the task from **Backlog** to **Planning**. Architects claim tasks in Planning; an empty board or a task left in Backlog gives them nothing to plan.
+| Agent | Windows | macOS / Linux |
+| --- | --- | --- |
+| Codex | `-AgentCommand codex` | `--agent codex` |
+| Gemini CLI | `-AgentCommand gemini` | `--agent gemini` |
+| Skip agent installation | `-AgentCommand none` | `--agent none` |
 
-### 4. Plan, approve, implement, and review
+Grok Build is supported by the agent launchers. The Windows installer also accepts `-AgentCommand grok`; on macOS/Linux, install Grok Build separately.
 
-In the board's **Agents** menu, choose **Architect**, then your installed CLI. When the task shows **Awaiting Approval** in the Planning column, open it, read the plan, and click **Approve**. Then launch **Worker** and **QA** from the same menu. Keep their terminals open while they work.
+Keep the Moe folder after installation. Open a **new terminal**, go to your target project, and run your selected coding CLI once to sign in to your provider account.
 
-To launch from a terminal instead, open a **new terminal in the Moe-s-Tavern checkout**, then run one role per terminal:
+### 2. Open the board
+
+1. In JetBrains, open **Settings / Preferences → Plugins → gear icon → Install Plugin from Disk**.
+2. Select the ZIP in `moe-jetbrains/build/distributions/` and restart the IDE.
+3. Open **your target Git project**, then open the **Moe** tool window. The plugin initializes `.moe/` and starts the daemon. Wait for **Connected**.
+
+Use the freshly built plugin so it matches your checkout. Published release downloads may contain an older implementation.
+
+### 3. Run your first task
+
+1. Open **Project Settings** and keep **Approval Mode: CONTROL**.
+2. Click **+ Epic**, create an epic such as `First task`, then use the **+** in its **Backlog** column to create a task. Give it a clear description and Definition of Done.
+3. Drag the task to **Planning**. In **Agents**, choose **Architect**, then your installed CLI. Architects claim tasks in Planning, so a task left in Backlog will wait.
+4. When the task shows **Awaiting Approval**, open it, read the plan, and click **Approve**.
+5. Launch **Worker** and **QA** from the same menu. Keep their terminals open and follow the task through **Working → Review → Done**.
+
+Open the completed task to inspect its steps, verification results, and QA summary, then review the changed files and recorded commit in Git. By default, the launchers commit task changes and attempt to push them; check any reported Git or verification failure before treating the task as delivered.
+
+Once one task completes, use **Agents → All Agents** to start the team together. If a step stalls, use the [first-task troubleshooting guide](docs/GETTING_STARTED.md#when-a-step-does-not-work).
+
+<details>
+<summary>Launch agents from external terminals</summary>
+
+Open a new terminal in the Moe checkout and run one role per terminal. Change `architect` to `worker` or `qa` for the next roles.
+
+**Windows:**
 
 ```powershell
-# Windows; change architect to worker or qa for the next roles
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\moe-agent.ps1 -Role architect -Project "C:\your\project"
 ```
 
+**macOS / Linux:**
+
 ```bash
-# macOS / Linux; change architect to worker or qa for the next roles
 ./scripts/moe-agent.sh --role architect --project "/your/project"
 ```
 
-These examples use Claude Code. For Codex, add `-Command codex` on Windows or `--command codex` on macOS/Linux. The launch scripts start the daemon if needed. For explicit initialization, run `moe-daemon init --project "/your/project"` in its own terminal; it keeps running until stopped.
+These examples use Claude Code. For Codex, add `-Command codex` on Windows or `--command codex` on macOS/Linux. The launchers configure the agent's Moe connection and start the daemon if needed.
 
-### 5. Check the result
+</details>
 
-The task should move through **Working → Review → Done**. Open it to inspect the implementation steps, verification result, and QA summary, then review the changed files and recorded commit in Git. By default the launchers commit task changes and attempt to push them; review any reported Git or verification failure before treating the task as delivered.
+<details>
+<summary>Use VS Code / Antigravity</summary>
 
-If a step stalls, use the [first-task troubleshooting guide](docs/GETTING_STARTED.md#when-a-step-does-not-work). Once one task completes, use **Agents → All Agents** to start the team together.
-
----
-
-## JetBrains Plugin Installation
-
-The plugin provides a visual Kanban board inside your IDE (IntelliJ IDEA, PyCharm, WebStorm, etc.)
-
-### Prerequisites
-
-- **JDK 17+** - [Download](https://adoptium.net/)
-- **JetBrains IDE** - Any 2024.1+ version
-
-### Build the Plugin
-
-The plugin bundles the daemon, proxy, agent scripts, and role documentation. Build the daemon and proxy first:
-
-**Mac / Linux:**
-```bash
-cd packages/moe-daemon && npm install && npm run build
-cd ../moe-proxy && npm install && npm run build
-cd ../../moe-jetbrains
-./gradlew buildPlugin
-```
+After running the installer above, open a new terminal in the Moe folder and build the [VS Code / Antigravity extension](moe-vscode/README.md):
 
 **Windows:**
+
 ```powershell
-cd packages\moe-daemon; npm install; npm run build
-cd ..\moe-proxy; npm install; npm run build
-cd ..\..\moe-jetbrains
-.\gradlew.bat buildPlugin
+cd moe-vscode
+npm.cmd install
+npm.cmd run package
 ```
 
-The plugin zip will be created at `moe-jetbrains/build/distributions/moe-jetbrains-*.zip`
+**macOS / Linux:**
 
-### Install in Your IDE
-
-**Option 1: Install from Disk (Recommended)**
-
-1. Open your JetBrains IDE
-2. Go to **Settings/Preferences** → **Plugins**
-3. Click the **⚙️ gear icon** → **Install Plugin from Disk...**
-4. Select the zip file from `moe-jetbrains/build/distributions/`
-5. Restart the IDE
-
-**Option 2: Development Mode**
-
-Run the plugin in a sandbox IDE for testing:
 ```bash
-cd moe-jetbrains
-./gradlew runIde    # Mac/Linux
-.\gradlew.bat runIde  # Windows
+cd moe-vscode
+npm install
+npm run package
 ```
 
-### Plugin Location (Manual Install)
+Use **Extensions: Install from VSIX** to install the resulting `.vsix`, open your target project, then run **Moe: Connect to Daemon**. See the extension's README for board commands and connection options. JetBrains is the primary first-run path documented here.
 
-If you prefer to extract manually:
+</details>
 
-| OS | Plugin Directory |
-|----|------------------|
-| **Windows** | `%APPDATA%\JetBrains\<IDE><version>\plugins\` |
-| **Mac** | `~/Library/Application Support/JetBrains/<IDE><version>/plugins/` |
-| **Linux** | `~/.config/JetBrains/<IDE><version>/plugins/` |
+## Choose your level of control
 
-Extract the zip contents to a `moe-jetbrains` folder in the plugins directory, then restart your IDE.
+Set the approval mode in **Project Settings**:
 
-### Using the Plugin
+| Mode | Plan approval | Best when |
+| --- | --- | --- |
+| **CONTROL** — default | You review and approve plans before implementation. | You are getting started or want to inspect each approach. |
+| **SPEED** | Plans are automatically approved after a configurable delay, giving you a window to intervene. | You want plans to move forward automatically with a review window. |
+| **TURBO** | Submitted plans are automatically approved immediately. | You want autonomous plan approval for a scope you have already defined. |
 
-1. Open a project in your JetBrains IDE
-2. The Moe tool window appears in the right sidebar
-3. The plugin auto-starts the daemon (bundled with the plugin) and connects
-4. Create epics and tasks using the toolbar buttons
-5. AI agents will claim tasks and submit plans for your approval
+Agent review and project rules support your workflow. Inspect the results and keep your normal repository checks and merge protections.
 
----
+## Extend Moe
 
-## Architecture
+Moe connects its IDE interfaces and coding agents through a local TypeScript daemon and an MCP proxy. Use the [MCP reference](docs/MCP_SERVER.md) and [architecture guide](docs/ARCHITECTURE.md) to build integrations or understand the runtime.
 
-```mermaid
-graph LR
-    subgraph IDE
-        Plugin[JetBrains Plugin]
-    end
-
-    subgraph Backend
-        Supervisor[Supervisor] --> Daemon[Moe Daemon]
-        Daemon --> Files[".moe/ state"]
-    end
-
-    subgraph Agents
-        Claude[Claude Code]
-        Codex[Codex]
-        Gemini[Gemini]
-        Grok[Grok Build]
-    end
-
-    Plugin <-->|WebSocket| Daemon
-    Claude <-->|MCP| Daemon
-    Codex <-->|MCP| Daemon
-    Gemini <-->|MCP| Daemon
-    Grok <-->|MCP| Daemon
-    Claude <-->|MCP| Serena["Serena MCP<br/>(code intel + memory)"]
-    Codex <-->|MCP| Serena
-    Gemini <-->|MCP| Serena
-    Grok <-->|MCP| Serena
-```
-
-**Key Principles:**
-- The `.moe/` folder is the source of truth. The daemon is the sole writer.
-- The **supervisor** auto-restarts the daemon on crash with exponential backoff.
-- **Cross-session memory** is delegated to the **Serena MCP server** (a flat `.serena/memories/` markdown store) — agents pull prior knowledge on task start and write handoff/learning notes before finishing.
-- The **skills system** mirrors `.moe/skills/` into each agent's tool path so vendored discipline (TDD, debugging, adversarial review) is always one `Skill` invocation away.
-- The agent wrapper (`scripts/moe-agent.*`) runs **pre-flight** (workspace + skill sync) and **post-flight** (branch-safety, commit hygiene) around every claimed task.
-
----
-
-## Project Structure
-
-```
-moe/
-├── packages/
-│   ├── moe-daemon/      # Node.js daemon (TypeScript)
-│   │   └── src/
-│   │       ├── tools/       # 40+ MCP tool implementations
-│   │       ├── state/       # State management + file watcher
-│   │       └── server/      # WebSocket + MCP adapter
-│   └── moe-proxy/       # MCP stdio proxy for agents
-├── moe-jetbrains/       # JetBrains IDE plugin (Kotlin)
-├── moe-vscode/          # VS Code / Antigravity extension
-├── docs/
-│   ├── ARCHITECTURE.md  # System design
-│   ├── MCP_SERVER.md    # MCP tool reference (40+ tools)
-│   ├── SCHEMA.md        # Data schema
-│   ├── MEMORY.md        # Memory system guide
-│   ├── DEVELOPMENT.md   # Dev guide
-│   ├── TROUBLESHOOTING.md
-│   ├── skills/          # Vendored agent skills (mirrored into .moe/skills/)
-│   │   ├── manifest.json
-│   │   ├── moe-planning/, moe-qa-loop/
-│   │   ├── test-driven-development/, systematic-debugging/
-│   │   ├── adversarial-self-review/, regression-check/
-│   │   ├── receiving-code-review/, verification-before-completion/
-│   │   ├── explore-before-assume/, writing-plans/
-│   │   └── using-git-worktrees/
-│   └── roles/
-│       ├── architect.md  # Plan mode, conversational planning, memory guidance
-│       ├── worker.md     # Branch safety, skills usage, mention protocol
-│       ├── qa.md
-│       └── governor.md   # Oversight, escalation ladder, signal cheat sheet
-└── scripts/             # Agent launcher & install scripts
-    ├── moe-agent.sh     # Mac/Linux agent launcher (pre-flight + post-flight)
-    ├── moe-agent.ps1    # Windows agent launcher (pre-flight + post-flight)
-    ├── moe-team.sh      # Launch full agent team
-    └── install-all.ps1  # Windows full install
-```
-
----
-
-## Agent Roles — Architect, Worker, QA
-
-Moe runs every task through a four-role pipeline: architect plans, worker codes, QA reviews, and a dedicated governor watches the fleet. Each role claims tasks in a specific status (the governor doesn't claim — it oversees), owns a different MCP toolset, and is wired to its own skill bundle. Humans are the gate between roles (or you can dial that gate down with [Approval Modes](#approval-modes)).
-
-```mermaid
-flowchart LR
-    BL[BACKLOG] --> PL[PLANNING]
-    PL -->|architect: moe.submit_plan| AA[AWAITING_APPROVAL]
-    AA -->|human / auto-approve| WK[WORKING]
-    WK -->|worker: moe.complete_task| RV[REVIEW]
-    RV -->|qa: qa_approve| DN[DONE]
-    RV -->|qa: qa_reject| WK
-    RV -.->|governor: set_task_status (rejection loop)| PL
-    WK -.->|governor: release_task (confirmed crash only)| WK
-```
-
-### 1. Architect — the planner
-
-- Claims `PLANNING` tasks via `moe.claim_next_task {workerId:"architect"}`.
-- Explores the codebase, then submits an implementation plan with `moe.submit_plan` (steps, files, rails, DoD).
-- Can **propose new rails** with `moe.propose_rail` and route them to humans for approval.
-- Runs in interactive TUI by default — uses `superpowers:brainstorming` to clarify ambiguities with the human before drafting.
-- On an empty PLANNING queue, idles via `moe.wait_for_task` until the next plan is needed. Oversight is **not** the architect's job — see Governor.
-- Skills auto-loaded: `moe-planning`, `writing-plans`, `explore-before-assume`.
-- Role guide: [`docs/roles/architect.md`](docs/roles/architect.md).
-
-### 2. Worker — the coder
-
-- Claims `WORKING` tasks (only after human/auto plan approval).
-- Walks the plan with `moe.start_step` → edits/tests → `moe.complete_step` per step.
-- Pre-flight preloads the task (`claim_next_task` + `get_context`) and snapshots a per-task baseline of the shared checkout; post-flight enforces **branch safety** (never auto-commit to `main`/`master`, peel onto `moe/work-<YYYY-MM-DD>` instead) and **lands on every exit** — a completion commit when the task reached REVIEW, a `wip(task-<id>)` checkpoint on any other exit, a rescue ref under `refs/moe/rescue/` when a gate or commit fails — staging only the paths attributed to the task, never `git add -A`.
-- Finishes with `moe.complete_task` only after running `regression-check` and `adversarial-self-review`.
-- Skills auto-loaded: `test-driven-development`, `systematic-debugging`, `adversarial-self-review`, `regression-check`, `verification-before-completion`, `receiving-code-review`.
-- Role guide: [`docs/roles/worker.md`](docs/roles/worker.md).
-
-### 3. QA — the reviewer
-
-- Claims `REVIEW` tasks. Reads plan + diff, verifies the Definition of Done, runs tests.
-- **PASS** → `moe.qa_approve` (task moves to `DONE`).
-- **FAIL** → `moe.qa_reject` with structured `rejectionDetails` so the worker has actionable feedback (task drops back to `WORKING`, never to `BACKLOG`).
-- Skill auto-loaded: `moe-qa-loop`.
-- Role guide: [`docs/roles/qa.md`](docs/roles/qa.md).
-
-### 4. Governor — the overseer
-
-- Never claims tasks. `moe.claim_next_task` routes governors straight to `moe.enter_governance`.
-- Watches `#governors` for auto-pushed signals: `🚧` worker blocks, `❌` QA rejections, `⚠️` stale-worker alerts (ping-first — quiet ≠ dead, never release on idle alone), `🔓` task releases, and `📋` new PLANNING announcements (informational).
-- Triages: ping a worker, ping the architect, `moe.propose_rail` for rail conflicts, `moe.release_task` for confirmed crashes (never on idle time alone — with human confirmation), `moe.set_task_status` back to PLANNING for QA rejection loops.
-- Runs in interactive TUI by default — the human steers escalation decisions via the REPL.
-- Role guide: [`docs/roles/governor.md`](docs/roles/governor.md).
-
-### Cross-cutting
-
-- **Memory** — every role uses the Serena MCP server's memory tools (`list_memories` / `read_memory` / `write_memory` / `edit_memory`) to carry knowledge across sessions, organized by a topic naming convention (`gotcha-<area>`, `decision-<area>`, `task-<id>-handoff`, …). See [`docs/MEMORY.md`](docs/MEMORY.md).
-- **Chat** — agents talk via `moe.chat_send` with @mentions and channels; tagged agents must reply (Mention Response Protocol).
-- **Effort** — Claude-CLI agents launch with `--effort max` by default; the agent process respawns per task so prompts stay tight.
-
----
-
-## Approval Modes
-
-Configure in `.moe/project.json`:
-
-| Mode | Behavior |
-|------|----------|
-| **CONTROL** | Manual approval required (default) |
-| **SPEED** | Auto-approve after delay (configurable) |
-| **TURBO** | Instant auto-approve |
-
----
+Customize [role guidance](docs/roles/) and [agent skills](docs/skills/) for your project. Optionally connect [Serena](docs/MEMORY.md) for code navigation and shared memory.
 
 ## Documentation
 
-- [Architecture Overview](docs/ARCHITECTURE.md)
-- [MCP Server API](docs/MCP_SERVER.md) - 40+ tools (chat, governance, teams, rails; memory via Serena MCP)
-- [Memory System](docs/MEMORY.md) - How agent memory works
-- [Skills Manifest](docs/skills/manifest.json) - Per-role skill bindings
-- [Data Schema](docs/SCHEMA.md)
-- [Development Guide](docs/DEVELOPMENT.md)
-- [Troubleshooting](docs/TROUBLESHOOTING.md)
-- Role guides: [architect](docs/roles/architect.md), [worker](docs/roles/worker.md), [qa](docs/roles/qa.md)
+| Start here | Go deeper |
+| --- | --- |
+| [First task walkthrough](docs/GETTING_STARTED.md) | [Architecture](docs/ARCHITECTURE.md) |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | [MCP tools](docs/MCP_SERVER.md) |
+| [Configuration](docs/CONFIGURATION.md) | [Data schema](docs/SCHEMA.md) |
+| [Memory and Serena](docs/MEMORY.md) | [Development guide](docs/DEVELOPMENT.md) |
 
----
+Role guides: [Architect](docs/roles/architect.md) · [Worker](docs/roles/worker.md) · [QA](docs/roles/qa.md) · [Governor](docs/roles/governor.md).
 
-## Contributing
+## Contribute
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing`)
-5. Open a Pull Request
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
----
+Try Moe on a small task and tell us what worked or got in your way. [Report a bug or request a feature](https://github.com/yaront1111/Moe-s-Tavern/issues), or see the [contribution guide](CONTRIBUTING.md) to help build it.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
-
----
-
-<p align="center">
-  <em>"Welcome to Moe's Tavern - where AI agents come to get their work done!"</em>
-</p>
+[MIT](LICENSE).


### PR DESCRIPTION
The README buried the product workflow under repeated feature lists and setup details. Lead with the value of coordinating coding agents, the actual IDE board, a concise feature table, and the plan-to-QA workflow. Keep one primary JetBrains setup path and expandable terminal/VS Code instructions.

Feature descriptions now match the implementation, including optional Serena memory, delayed SPEED approval, immediate TURBO approval, and task delivery checks. Windows extension packaging uses npm.cmd so the instructions work under PowerShell's script execution policy.

Validation: independently checked feature and onboarding claims against source; verified local links and anchors, install/launch command examples, and GitHub Markdown rendering; git diff --check passed. Only README.md changes.