### PR TITLE
ci: install the coverage provider at the installed vitest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: packages/moe-daemon
 
       - name: Install daemon coverage provider
-        run: npm install --no-save --no-package-lock @vitest/coverage-v8@^4.0.0
+        run: npm install --no-save --no-package-lock "@vitest/coverage-v8@$(node -p "require('vitest/package.json').version")"
         working-directory: packages/moe-daemon
 
       - name: Test daemon with coverage
@@ -109,7 +109,7 @@ jobs:
         working-directory: packages/moe-proxy
 
       - name: Install proxy coverage provider
-        run: npm install --no-save --no-package-lock @vitest/coverage-v8@^4.0.0
+        run: npm install --no-save --no-package-lock "@vitest/coverage-v8@$(node -p "require('vitest/package.json').version")"
         working-directory: packages/moe-proxy
 
       - name: Test proxy with coverage


### PR DESCRIPTION
## Summary
- The daemon and proxy coverage steps hardcoded `@vitest/coverage-v8@^4.0.0`, so dependabot's vitest 5.0.0 bumps (#168, #170) fail `npm install` on an ERESOLVE peer conflict before any test runs.
- Install the provider at whatever vitest version is actually installed (`node -p "require('vitest/package.json').version"`), so the step follows future major bumps too.
- Verified locally: both dependabot branches pass `npm run test:coverage` with `@vitest/coverage-v8@5.0.0` (daemon 1105/1105, proxy 59/59).

## Test plan
- [ ] CI "Test TypeScript" green on this PR (vitest 4 path)
- [ ] Rebase #168/#170 on top and confirm green (vitest 5 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)