### PR TITLE
fix(install): retry Node downloads on HTTP errors; audit hardening pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
           cache-dependency-path: |
             packages/moe-daemon/package-lock.json
             packages/moe-proxy/package-lock.json
+            packages/moe-claude-plugin/package-lock.json
+
+      - name: Build and test Claude plugin
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+          npm test
+        working-directory: packages/moe-claude-plugin
 
       - name: Install daemon dependencies
         run: npm install --no-audit --no-fund
@@ -257,5 +265,6 @@ jobs:
       - name: Test VS Code daemon startup
         run: |
           npm ci
+          npm run compile
           npm test
         working-directory: moe-vscode

--- a/.moe/roles/architect.reference.md
+++ b/.moe/roles/architect.reference.md
@@ -1,4 +1,4 @@
-<!-- moe-generated: sha=da49d54ff8fe -->
+<!-- moe-generated: sha=c540e2042420 -->
 
 # Architect — Reference
 
@@ -84,3 +84,26 @@ Cross-session memory lives in the Serena MCP server (`.serena/memories/`), not i
 - "Confirmed: `retry-budget = 5`. Updating step 2 now."
 - "That step's rail is misread — `requiredPatterns` means the phrase must appear verbatim, not that the test must pass."
 - "No, don't split this task; the file-ownership boundary breaks at the schema module. I'll open a separate epic."
+
+## Self-improvement: fix Moe itself
+
+Moe's own tooling is in scope for you. When planning is blocked or distorted by a defect in the Moe stack — a tool that refuses the very call its own instructions told you to make, a launcher that injects a contradictory prompt, a role doc or skill that contradicts the runtime, a role gate with no escape hatch — **fix it at the source and push to `main`, so every project gets the fix.** Do not plan around it, and do not encode the workaround as a rail: a rail whose only job is to paper over a tool bug is a bug report that was never filed, and planning around a broken tool charges every future session the same detour.
+
+**The Moe source repo is separate from the product repo you are working in** — it is the checkout of `Moe-s-Tavern` (commonly `D:/projexts/moes`; confirm before editing). Edit the source of truth, never a generated artifact:
+
+| What is wrong | Edit | Never edit |
+|---|---|---|
+| A role doc (including this file) | `docs/roles/<role>.md` | `.moe/roles/*`, `packages/moe-daemon/src/generated/initFiles.ts` |
+| Skill text | `docs/skills/<skill>/SKILL.md` | `.moe/skills/*` |
+| Daemon tool or logic | `packages/moe-daemon/src/**` | `packages/moe-daemon/dist/**` |
+| Seat launcher / injected pre-flight prompt | `scripts/moe-agent.ps1` **and** `scripts/moe-agent.sh` | — |
+
+Rules that keep this safe:
+- **Both launchers, or neither.** `moe-agent.ps1` and `moe-agent.sh` are twins. A fix landed in one and not the other is a new bug on the other platform.
+- **Generated files regenerate; hand-edits are erased.** `npm run build` in `packages/moe-daemon` runs `prebuild`, which restamps `initFiles.ts` from `docs/roles/` and `docs/skills/`. A doc edited under `.moe/roles/` is overwritten at the next daemon upgrade, so it fixes nothing.
+- **Prove it.** Run the daemon's tests for the surface you touched (`npm test` in `packages/moe-daemon`), and syntax-check any launcher you edited: `bash -n scripts/moe-agent.sh`, and for the `.ps1` a `[System.Management.Automation.Language.Parser]::ParseFile(...)` check. Land a regression test with the fix wherever the surface has a test file.
+- **Small, scoped, separate.** One commit for the defect, quoting the observed failure — the exact refusal string, the rendered bad prompt — in the message. Never sweep unrelated dirt in, and never mix it with product work.
+- **Push to `main`.** That is what makes the fix reach every project; a fix sitting on a local branch helps nobody. If `main` refuses the push (branch protection, non-linear history), stop and hand the human the branch name — never force.
+- **It is not part of your task's diff.** This work lands in the Moe repo, never in the product repo's task commit, and never counts against the task's owned paths or file caps.
+
+Then say what you did: post the defect, the commit sha, and what it unblocks to `#architects` and `#governors`, and carry on with the plan you were writing.

--- a/.moe/roles/governor.md
+++ b/.moe/roles/governor.md
@@ -1,4 +1,4 @@
-<!-- moe-generated: sha=f882385984d6 -->
+<!-- moe-generated: sha=2556278c295b -->
 
 # Governor
 
@@ -78,3 +78,29 @@ When the project is in `CONTROL` approval mode, `moe.submit_plan` now also cross
 ## Mention Response Protocol
 
 When tagged (`@governor`, `@governors`, `@all`, or direct ID), reply via `moe.chat_send` BEFORE any other tool call. Reply substantively — answer the question, confirm the handoff, or say why you can't. Do not skip the reply to "look efficient." The Loop Guard (max 4 agent-to-agent hops per channel) is the throttle; you don't need your own.
+
+## Self-improvement: fix Moe itself
+
+Moe's own tooling is in scope for you, and you are the role most likely to spot the defect — you watch every seat, so you see the same stall recur across sessions. When a stall's root cause is the Moe stack itself — a tool that refuses the very call its own instructions told a seat to make, a launcher that injects a contradictory pre-flight prompt, a role doc or skill that contradicts the runtime, a role gate with no escape hatch — **fix it at the source and push to `main`, so every project gets the fix.**
+
+This outranks step 3 of the escalation ladder. `moe.propose_rail` is for a rail that is genuinely wrong; it is NOT the answer to a tool bug. A rail whose only job is to route agents around a broken tool is a bug report that was never filed — it makes every future session pay the same detour and buries the defect under prose. If you catch yourself drafting a rail that says "when the tool refuses you, ask a governor instead", stop and fix the tool.
+
+**The Moe source repo is separate from the product repo the fleet is working in** — it is the checkout of `Moe-s-Tavern` (commonly `D:/projexts/moes`; confirm before editing). Edit the source of truth, never a generated artifact:
+
+| What is wrong | Edit | Never edit |
+|---|---|---|
+| A role doc (including this file) | `docs/roles/<role>.md` | `.moe/roles/*`, `packages/moe-daemon/src/generated/initFiles.ts` |
+| Skill text | `docs/skills/<skill>/SKILL.md` | `.moe/skills/*` |
+| Daemon tool or logic | `packages/moe-daemon/src/**` | `packages/moe-daemon/dist/**` |
+| Seat launcher / injected pre-flight prompt | `scripts/moe-agent.ps1` **and** `scripts/moe-agent.sh` | — |
+
+Rules that keep this safe:
+- **Both launchers, or neither.** `moe-agent.ps1` and `moe-agent.sh` are twins. A fix landed in one and not the other is a new bug on the other platform.
+- **Generated files regenerate; hand-edits are erased.** `npm run build` in `packages/moe-daemon` runs `prebuild`, which restamps `initFiles.ts` from `docs/roles/` and `docs/skills/`. A doc edited under `.moe/roles/` is overwritten at the next daemon upgrade, so it fixes nothing.
+- **Prove it.** Run the daemon's tests for the surface you touched (`npm test` in `packages/moe-daemon`), and syntax-check any launcher you edited: `bash -n scripts/moe-agent.sh`, and for the `.ps1` a `[System.Management.Automation.Language.Parser]::ParseFile(...)` check. Land a regression test with the fix wherever the surface has a test file.
+- **Small, scoped, separate.** One commit for the defect, quoting the observed failure — the exact refusal string, the rendered bad prompt — in the message. Never sweep unrelated dirt in, and never mix it with product work.
+- **Push to `main`.** That is what makes the fix reach every project; a fix sitting on a local branch helps nobody. If `main` refuses the push (branch protection, non-linear history), stop and hand the human the branch name — never force.
+- **A live seat keeps its prompt.** Launcher and role-doc fixes reach a seat at its NEXT spawn, not this one. Do not release or restart a healthy worker to pick up a doc change; tell the fleet in chat what changed and let it land naturally.
+- **Governance still applies to you.** Fixing Moe is not planning and not coding product — it is in your lane. But an edit that changes what the fleet may claim (a role gate, a claim filter, a dependency rule) is a hard call: surface it to the human before you push, the same as a release.
+
+Then post it in `#governors`: the defect, the commit sha, and what it unblocks. Future-you reads that log to notice the second occurrence of a pattern you have already fixed once.

--- a/.moe/roles/worker.reference.md
+++ b/.moe/roles/worker.reference.md
@@ -1,4 +1,4 @@
-<!-- moe-generated: sha=4b041787b980 -->
+<!-- moe-generated: sha=00d768586ec5 -->
 
 # Worker — Reference
 
@@ -45,6 +45,22 @@ moe.propose_rail {
 
 Don't use this to dodge inconvenient rails — adversarial-self-review and receiving-code-review will catch it, and QA will reject. The proposal lands in `.moe/proposals/`; once approved, retry the step.
 
+## Filing a bug as a card
+
+A bug outside your step's scope is a new card, never an in-line fix — the plan's scope is what QA reviews and what the wrapper attributes. Example (`workerId` is proxy-injected, so `createdBy` resolves to `WORKER`; the row lands in BACKLOG, human-gated, and every `warnings[]` entry is advisory):
+
+```
+moe.create_task {
+  epicId:           "<your task's epicId>",
+  title:            "bug: retry budget ignored when RETRY_MAX is unset",
+  description:      "Repro: unset RETRY_MAX, run `npm test -- retry` — expected 5 attempts, got 1 (src/retry.ts:41). Found from task-<yours> step 2.",
+  definitionOfDone: ["`npm test -- retry` green with RETRY_MAX unset"],
+  dependsOn:        ["<your taskId>"]
+}
+```
+
+Include `dependsOn` only when the fix must land after your task; otherwise omit it. Two outcomes: it does not block you → note the new task id in `complete_step.note` and continue the step; it does → `moe.report_blocked { taskId, reason, blockedOnTaskIds: ["<bug task id>"] }` instead (your seat is freed, and your task auto-unblocks when the bug is DONE). Never both `dependsOn: [<your taskId>]` on the bug and `blockedOnTaskIds` on it from your task — that is a dependency cycle; the daemon drops the id with a `DEPENDENCY_CYCLE` warning.
+
 ## Commits, checkpoints and rescue refs
 
 You never run `git commit` for a task. The wrapper lands your work after the CLI exits — on **every** exit, not only on success:
@@ -55,7 +71,7 @@ You never run `git commit` for a task. The wrapper lands your work after the CLI
 | Any other exit — WORKING, BLOCKED, PLANNING, AWAITING_APPROVAL, status lookup failed | `wip(task-<id>): <title> [status=<S> role=<r> cli-exit=<N>]` checkpoint, pushed per `checkpointPush` | shared branch |
 | `qualityGate` failed, branch peel failed, commit failed, three CAS losses, Ctrl+C | `rescue(task-<id>): <title> [reason=…]` | `refs/moe/rescue/<taskId>/<ts>` — never a branch, never pushed |
 
-What gets staged is decided per path, never `git add -A`: **ASSERTED** (every completed step's `modifiedFiles`, `moe.declare_files`, paths you already landed) is committed no matter what; **PLANNED** (the plan's `affectedFiles`/`newFiles` you did not report) only if it changed since your session's baseline; **TOOL** (files your Edit/Write tool calls touched — claude only) always; **MEASURED** (undeclared, changed) only when no other worker is live. A peer's declared path, a path that was already dirty before your task, and anything under `.moe/` (except your own task record), `.mcp.json`, `.codex/`, `.gemini/`, `.claude/agents/`, `.worktrees/` are skipped with a `[skip] <path> MOE_ATTR_*` line. Undeclared edits with peers active are reported as `MOE_ATTRIBUTION_UNRESOLVED` and never staged — the next session sees them in `get_context.unattributedPaths` with a `moe.declare_files` hint.
+What gets staged is decided per path, never `git add -A`: **ASSERTED** (every completed step's `modifiedFiles`, `moe.declare_files`, paths you already landed) is committed no matter what; **PLANNED** (the plan's `affectedFiles`/`newFiles` you did not report) only if it changed since your session's baseline; **TOOL** (files your Edit/Write tool calls touched — claude only) always; **MEASURED** (undeclared, changed) only when no other worker is live. A peer's declared path, a path that was already dirty before your task, and anything under `.moe/` (except your own task record), `.mcp.json`, `.codex/`, `.gemini/`, `.grok/`, `.claude/agents/`, `.worktrees/` are skipped with a `[skip] <path> MOE_ATTR_*` line. Undeclared edits with peers active are reported as `MOE_ATTRIBUTION_UNRESOLVED` and never staged — the next session sees them in `get_context.unattributedPaths` with a `moe.declare_files` hint.
 
 Practical rules:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ npm run lint                                                        # repo root:
 
 Run daemon tests after touching daemon code; run `./gradlew test` after touching Kotlin. Proxy and claude-plugin have their own `npm test`. `npm run lint` enforces a hard 40-line cap on `docs/roles/{architect,worker,qa}.md` (governor + `*.reference.md` exempt) — keep role docs terse, put detail in the `.reference.md` files.
 
-CI (`.github/workflows/ci.yml`, PRs to main): daemon+proxy build + `test:coverage`, JetBrains `buildPlugin` + `./gradlew test`, and a 3-OS build matrix (ubuntu/windows/macos). Root lint and claude-plugin tests are NOT CI-enforced. Daemon changes also trigger a Docker build of `packages/moe-daemon/Dockerfile`. Releases are tag-driven: pushing `v*` builds everything, publishes daemon+proxy to npm, attaches the plugin zip + .vsix to a GitHub Release, and publishes to JetBrains Marketplace.
+CI (`.github/workflows/ci.yml`, PRs to main): role-doc lint, daemon+proxy build + `test:coverage`, Claude plugin build + tests, JetBrains `buildPlugin` + `./gradlew test`, and a 3-OS build matrix (ubuntu/windows/macos) including VS Code typecheck + startup tests. Daemon changes also trigger a Docker build of `packages/moe-daemon/Dockerfile`. Releases are tag-driven: pushing `v*` builds everything, publishes daemon+proxy to npm, attaches the plugin zip + .vsix to a GitHub Release, and publishes to JetBrains Marketplace.
 
 ## Working in this repo
 

--- a/docs/audits/2026-09-07-maturity.md
+++ b/docs/audits/2026-09-07-maturity.md
@@ -1,0 +1,52 @@
+# Moe maturity audit — 2026-09-07
+
+Audited the daemon, MCP proxy, primary JetBrains connection lifecycle, verification gates, and packaged IDE runtimes. The investigation used independent reviewers, real sockets and subprocesses, controlled concurrent operations, and injected persistence failures. This is a verified hardening pass, not an exhaustive repository certification.
+
+## Reproduced failures and repairs
+
+| Area | Before | After |
+| --- | --- | --- |
+| Resource persistence | Failed acquire, renewal, queue, release, and reap writes could change published in-memory state. | Mutations use private copies and publish only after a successful write. |
+| Resource grant recovery | A task could resume before its lease was durable; partial writes could strand it after restart. | Persist the grant before resumption; reconcile incomplete grants and unblocks on the existing five-minute sweep. Expired or malformed leases do not authorize resumption. |
+| Resource queue | Ordinary release could grant capacity to a completed, parked, or deleted task. | Recheck queue eligibility on every grant and persist removal of inactive entries. |
+| Resource ownership | A resumed task could remain assigned to a missing, dead, or repurposed worker. | Restore assignment only when the worker still points at the task; otherwise make the task claimable. Quiet valid owners remain assigned. |
+| MCP shutdown | Connection maps were cleared before parked RPC cleanup, leaving waiters alive. | Cancel task, chat, and resource waits before clearing ownership; refuse new connections during shutdown. |
+| MCP asynchronous setup | Disconnect during heartbeat, mutex acquisition, or persistence could register an orphan waiter or acquire a resource afterward. | Propagate connection lifetime checks through asynchronous waiter setup. Already-persisted task-keyed leases and queues survive transport cancellation. |
+| MCP waiter ownership | Invalid replacements and undispatched batch entries could steal another socket's waiter and cancel it. | Transfer ownership only when the replacement waiter is actually registered. |
+| Plugin messages | A JSON `null` message threw again inside error handling and left the client without a response. | Validate message envelopes before dispatch and return a structured error; subsequent PING still works. |
+| Proxy framing | The tail of an oversized input frame could execute as a new request. Unicode requests could bypass limits measured in string characters. | Discard through the rejected frame's newline and enforce UTF-8 byte limits. |
+| JetBrains connections | Retired `onOpen` callbacks could resurrect disposed/disconnected state; errors left abandoned sockets open; a delayed open notification could overtake disconnect. | Fence callbacks by current client and disposal state, close failed transports, and serialize open side effects with disconnect. |
+| Verification and packaging | Proxy tests could execute missing/stale `dist`; Claude plugin build/tests and VS Code typechecks were missing from CI; VSIX packaging included local logs and development scripts/tests. | Rebuild proxy before test/coverage gates, add the missing CI checks, and exclude those development artifacts from the VSIX. |
+
+Added **54 regression cases**: 46 daemon, 3 proxy, and 5 JetBrains. Existing assertions remain intact. Two resource-block tests now establish both sides of a real worker claim; three ownership fixtures explicitly simulate actual waiter registration.
+
+## Validation
+
+All commands completed successfully on Windows with Node 24 and JDK 17:
+
+| Gate | Result |
+| --- | --- |
+| Daemon `npm run test:coverage -- --reporter=dot` | 99 files, **1,145 tests passed**; 81.47% lines, 73.25% branches; existing coverage thresholds passed. |
+| Proxy `npm run test:coverage -- --reporter=dot` | 3 files, **62 tests passed**, including built-process framing regressions. |
+| JetBrains `gradlew.bat test --console=plain` | **68 tests passed**, no failures, errors, or skipped tests. |
+| Claude plugin `npm run build` and `npm test` | Build passed; **13 tests passed**. |
+| VS Code `npm run compile` and `npm test` | Typecheck passed; **7 tests passed**. |
+| Release-version, agent-runtime, and dependency script tests | **28 tests passed**. |
+| Daemon/proxy TypeScript builds; typecheck of all new daemon test files | Passed. |
+| JetBrains `buildPlugin test`; VS Code `npm run package` | Both package builds passed. |
+| Fresh onboarding using built runtime, extracted JetBrains ZIP, and extracted VSIX | Init, health, MCP, task/epic creation, architect claim, approval, doctor, and restart persistence passed for all three. |
+| VSIX archive inspection | Runtime entrypoints and launcher scripts present; no logs or root development scripts/tests. |
+| Role-doc lint, PowerShell wrapper parity, CI YAML inspection, `git diff --check` | Passed. |
+
+These are **1,323 passing test cases** across the listed test suites, plus the build and onboarding checks. Repeated focused runs are not added to that count. Proxy coverage percentages describe its in-process utilities; child-process transport tests are behavioral evidence and are not included in that coverage percentage.
+
+## Provenance and limits
+
+- Investigation baseline: remote `main` at `ca90af79282900affe087fb3fe3d5968bbfe5ad1`, isolated under `.worktrees/maturity-20260907`.
+- The existing main checkout started at `e42c00d94b0c46a583d3060a3dbf477377199b5c`, four commits behind remote, with five pre-existing modified files. The repairs are applied as an explicit scoped patch; those existing files are preserved.
+- After applying the patch, the original main checkout passed all 1,145 daemon tests, 62 proxy tests, and the daemon typecheck. The five pre-existing edited files were verified byte-for-byte unchanged.
+- No production daemon restart, commit, push, release, or remote CI run is part of this pass. The IDE packages are local verification artifacts, not releases.
+- Resource files and task files remain separate writes. Interrupted transitions recover through the existing five-minute sweep rather than a new transaction store.
+- Follow-up: JetBrains state updates already queued for the IDE event thread still lack a connection-generation fence. Investigate delivery after disconnect/reconnect separately.
+- Follow-up: proxy watch mode still requires rebuilding the executable after source changes; the ordinary test and coverage commands now rebuild automatically.
+- Follow-up: IDE packages still copy the development dependency tree and are roughly 62–64 MB compressed in this environment. Packaging only runtime dependencies needs a separate dependency-closure and cross-platform artifact test.

--- a/moe-jetbrains/src/main/kotlin/com/moe/services/MoeProjectService.kt
+++ b/moe-jetbrains/src/main/kotlin/com/moe/services/MoeProjectService.kt
@@ -239,23 +239,30 @@ class MoeProjectService @JvmOverloads constructor(
             newClient = object : WebSocketClient(uri) {
                 override fun onOpen(handshakedata: ServerHandshake?) {
                     wsLock.withLock {
+                        if (disposed.get() || wsClient !== this) {
+                            log.debug("Ignoring onOpen from retired WebSocket client")
+                            closeQuietly(this)
+                            return
+                        }
                         connecting = false
                         connected = true
                         reconnectAttempts = 0
                         daemonSupervisor.resetSpawnAttempts()
                         isManualDisconnect = false
                         daemonRegistration.register(daemonInfo.pid)
-                    }
-                    publishStatus(true, "Connected")
-                    // Drain any messages queued during reconnect
-                    while (true) {
-                        val queued = messageQueue.poll() ?: break
-                        try { handleMessage(queued) } catch (ex: Exception) {
-                            log.warn("Failed to process queued message", ex)
+                        // Keep status dispatch and refresh setup in the same transition:
+                        // disconnect must not finish before these open effects run.
+                        publishStatus(true, "Connected")
+                        // Drain any messages queued during reconnect
+                        while (true) {
+                            val queued = messageQueue.poll() ?: break
+                            try { handleMessage(queued) } catch (ex: Exception) {
+                                log.warn("Failed to process queued message", ex)
+                            }
                         }
+                        sendMessage("GET_STATE", JsonObject())
+                        startAutoRefresh()
                     }
-                    sendMessage("GET_STATE", JsonObject())
-                    startAutoRefresh()
                 }
 
                 override fun onMessage(message: String?) {
@@ -300,6 +307,7 @@ class MoeProjectService @JvmOverloads constructor(
                             return
                         }
                     }
+                    closeQuietly(this)
                     publishStatus(false, ex?.message ?: "WebSocket error")
                     scheduleReconnect()
                 }
@@ -327,11 +335,11 @@ class MoeProjectService @JvmOverloads constructor(
     }
 
     private fun disconnect(notifyStatus: Boolean) {
-        isManualDisconnect = true
-        reconnectAttempts = 0
-        stopAutoRefresh()
-        cancelConnectionTimers()
         val currentClient = wsLock.withLock {
+            isManualDisconnect = true
+            reconnectAttempts = 0
+            stopAutoRefresh()
+            cancelConnectionTimers()
             val client = wsClient
             wsClient = null
             connected = false

--- a/moe-jetbrains/src/test/kotlin/com/moe/services/MoeProjectConnectionTest.kt
+++ b/moe-jetbrains/src/test/kotlin/com/moe/services/MoeProjectConnectionTest.kt
@@ -1,0 +1,201 @@
+package com.moe.services
+
+import com.intellij.openapi.project.Project as IdeaProject
+import com.moe.model.DaemonInfo
+import com.moe.model.MoeState
+import com.moe.util.MoeProjectRegistry
+import org.java_websocket.WebSocket
+import org.java_websocket.client.WebSocketClient
+import org.java_websocket.handshake.ClientHandshake
+import org.java_websocket.server.WebSocketServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+import java.net.InetSocketAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+
+class MoeProjectConnectionTest {
+    @Test
+    fun `late open cannot undo manual disconnect`() = withConnection { fixture ->
+        val client = fixture.connect(41001)
+        fixture.service.disconnect()
+        client.closeBlocking()
+
+        client.onOpen(null)
+
+        assertFalse("A retired client must not reconnect the service", fixture.service.isConnected())
+        assertEquals(null, fixture.service.field("refreshFuture"))
+    }
+
+    @Test
+    fun `late open cannot resurrect a disposed service`() = withConnection { fixture ->
+        val client = fixture.connect(41002)
+        fixture.service.dispose()
+        client.closeBlocking()
+
+        client.onOpen(null)
+
+        assertFalse("Disposed service must remain disconnected", fixture.service.isConnected())
+        assertEquals(0, MoeProjectRegistry.daemonRefCountForTest(41002))
+    }
+
+    @Test
+    fun `retired open cannot replace the current daemon registration`() = withConnection { fixture ->
+        val oldClient = fixture.connect(41003)
+        fixture.service.disconnect()
+        oldClient.closeBlocking()
+        val currentClient = fixture.connect(41004)
+
+        oldClient.onOpen(null)
+
+        assertTrue(fixture.service.isConnected())
+        assertEquals(currentClient, fixture.service.field("wsClient"))
+        assertEquals(0, MoeProjectRegistry.daemonRefCountForTest(41003))
+        assertEquals(1, MoeProjectRegistry.daemonRefCountForTest(41004))
+    }
+
+    @Test
+    fun `socket error closes the abandoned transport`() = withConnection { fixture ->
+        val client = fixture.connect(41005)
+
+        client.onError(IllegalStateException("simulated transport failure"))
+
+        assertFalse(fixture.service.isConnected())
+        assertTrue("The server must observe the failed socket closing", fixture.closed.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun `disconnect wins while open is publishing its status`() {
+        val publishingOpen = CountDownLatch(1)
+        val resumeOpen = CountDownLatch(1)
+        val pauseFirstDispatch = AtomicBoolean(true)
+        val statuses = CopyOnWriteArrayList<Pair<Boolean, String>>()
+        withConnection(invokeLater = { action ->
+            if (pauseFirstDispatch.compareAndSet(true, false)) {
+                publishingOpen.countDown()
+                assertTrue("Open callback was not released", resumeOpen.await(5, TimeUnit.SECONDS))
+            }
+            action()
+        }) { fixture ->
+            fixture.service.addListener(object : MoeStateListener {
+                override fun onState(state: MoeState) {}
+                override fun onStatus(connected: Boolean, message: String) {
+                    statuses.add(connected to message)
+                }
+            })
+            val disconnected = CountDownLatch(1)
+            val disconnectThread = Thread {
+                fixture.service.disconnect()
+                disconnected.countDown()
+            }
+            try {
+                val client = fixture.startConnection(41006)
+                assertTrue("Open callback did not publish", publishingOpen.await(5, TimeUnit.SECONDS))
+                disconnectThread.start()
+                val lock = fixture.service.field("wsLock") as ReentrantLock
+                val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+                // Wait until disconnect either finishes or waits on the open callback's
+                // lock; no timing guess about which thread reached the critical section.
+                while (disconnected.count != 0L && !lock.hasQueuedThread(disconnectThread) && System.nanoTime() < deadline) {
+                    Thread.sleep(10)
+                }
+                assertTrue("Disconnect did not reach the connection transition", disconnected.count == 0L || lock.hasQueuedThread(disconnectThread))
+                resumeOpen.countDown()
+                assertTrue("Disconnect did not finish", disconnected.await(5, TimeUnit.SECONDS))
+                client.closeBlocking()
+
+                assertFalse(fixture.service.isConnected())
+                assertEquals(false to "Disconnected", statuses.last())
+                assertEquals(null, fixture.service.field("refreshFuture"))
+            } finally {
+                resumeOpen.countDown()
+                disconnectThread.join(5000)
+            }
+        }
+    }
+
+    private fun withConnection(
+        invokeLater: ((() -> Unit) -> Unit) = { action -> action() },
+        test: (ConnectionFixture) -> Unit
+    ) {
+        MoeProjectRegistry.clearDaemonRefCountsForTest()
+        val fixture = ConnectionFixture(invokeLater)
+        try {
+            test(fixture)
+        } finally {
+            fixture.close()
+            MoeProjectRegistry.clearDaemonRefCountsForTest()
+        }
+    }
+
+    private class ConnectionFixture(invokeLater: ((() -> Unit) -> Unit)) {
+        val service = MoeProjectService(fakeProject(), invokeLater)
+        val closed = CountDownLatch(1)
+        private val started = CountDownLatch(1)
+        private val clients = mutableListOf<WebSocketClient>()
+        private val server = object : WebSocketServer(InetSocketAddress("127.0.0.1", 0), 1) {
+            override fun onStart() { started.countDown() }
+            override fun onOpen(conn: WebSocket?, handshake: ClientHandshake?) {}
+            override fun onMessage(conn: WebSocket?, message: String?) {}
+            override fun onClose(conn: WebSocket?, code: Int, reason: String?, remote: Boolean) {
+                closed.countDown()
+            }
+            override fun onError(conn: WebSocket?, ex: Exception?) {}
+        }
+
+        init {
+            server.start()
+            assertTrue("Loopback server did not start", started.await(5, TimeUnit.SECONDS))
+        }
+
+        fun connect(pid: Int): WebSocketClient {
+            val client = startConnection(pid)
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while ((!service.isConnected() || service.field("refreshFuture") == null) && System.nanoTime() < deadline) {
+                Thread.sleep(10)
+            }
+            assertTrue("Service did not connect to loopback server", service.isConnected())
+            assertTrue("Connection callback did not finish", service.field("refreshFuture") != null)
+            return client
+        }
+
+        fun startConnection(pid: Int): WebSocketClient {
+            val method = MoeProjectService::class.java.getDeclaredMethod("doConnect", DaemonInfo::class.java)
+            method.isAccessible = true
+            method.invoke(service, DaemonInfo(server.port, pid, "now", ""))
+            return (service.field("wsClient") as WebSocketClient).also { clients.add(it) }
+        }
+
+        fun close() {
+            service.dispose()
+            clients.forEach { it.closeBlocking() }
+            server.stop(1000)
+        }
+    }
+
+    companion object {
+        private fun MoeProjectService.field(name: String): Any? =
+            MoeProjectService::class.java.getDeclaredField(name).apply { isAccessible = true }.get(this)
+
+        private fun fakeProject(): IdeaProject = Proxy.newProxyInstance(
+            IdeaProject::class.java.classLoader,
+            arrayOf(IdeaProject::class.java)
+        ) { proxy, method, args ->
+            when (method.name) {
+                "getName" -> "Connection Test"
+                "getBasePath", "getService" -> null
+                "isDisposed" -> false
+                "toString" -> "ConnectionTestProject"
+                "hashCode" -> System.identityHashCode(proxy)
+                "equals" -> proxy === args?.firstOrNull()
+                else -> null
+            }
+        } as IdeaProject
+    }
+}

--- a/moe-vscode/.vscodeignore
+++ b/moe-vscode/.vscodeignore
@@ -9,3 +9,6 @@ node_modules/**
 !bundled/**
 !bundled/**/*
 bundled/**/.bin/**
+**/*.log
+tests/**
+scripts/**

--- a/packages/moe-daemon/src/server/McpAdapter.cancellation.test.ts
+++ b/packages/moe-daemon/src/server/McpAdapter.cancellation.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpAdapter, type JsonRpcRequest, type JsonRpcResponse } from './McpAdapter.js';
+import { ToolTestHarness } from '../tools/toolTestHarness.js';
+import { activeWaiters } from '../tools/waitForTask.js';
+import { activeResourceWaiters } from '../tools/waitForResource.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+function resultOf(response: JsonRpcResponse | JsonRpcResponse[] | null): unknown {
+  const single = Array.isArray(response) ? response[0] : response;
+  const result = single?.result as { content?: Array<{ text: string }> } | undefined;
+  return result?.content?.[0] ? JSON.parse(result.content[0].text) : response;
+}
+
+describe('MCP cancellation during waiter setup', () => {
+  const h = new ToolTestHarness();
+  let adapter: McpAdapter;
+  let connected: boolean;
+
+  beforeEach(async () => {
+    h.init();
+    h.setupMoeFolder();
+    h.createEpic();
+    h.createTask({ id: 'task-holder', status: 'WORKING', assignedWorkerId: 'worker-holder' });
+    h.createTask({ id: 'task-waiter', status: 'WORKING', assignedWorkerId: 'worker-waiter' });
+    h.createWorker({ id: 'worker-waiter' });
+    await h.state.load();
+    adapter = new McpAdapter(h.state);
+    connected = true;
+  });
+
+  afterEach(() => {
+    for (const registry of [activeWaiters, activeResourceWaiters]) {
+      for (const waiter of registry.values()) {
+        clearTimeout(waiter.timer);
+        waiter.unsubscribe();
+        waiter.resolve({ cancelled: true });
+      }
+      registry.clear();
+    }
+    vi.restoreAllMocks();
+    h.cleanup();
+  });
+
+  function call(name: string, args: Record<string, unknown>, batch = false) {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name, arguments: { workerId: 'worker-waiter', timeoutMs: 1000, ...args } },
+    };
+    return adapter.handle(batch ? [request] : request, { shouldContinue: () => connected });
+  }
+
+  it.each([false, true])('does not park a task wait after disconnect during heartbeat (batch=%s)', async batch => {
+    const touch = deferred();
+    vi.spyOn(h.state, 'touchWorker').mockImplementation(async () => { await touch.promise; return null; });
+    const pending = call('moe.wait_for_task', { statuses: ['REVIEW'] }, batch);
+    connected = false;
+    touch.resolve();
+
+    expect(resultOf(await pending)).toEqual({ hasNext: false, cancelled: true });
+    expect(activeWaiters.size).toBe(0);
+  });
+
+  it('does not acquire a resource after disconnect during heartbeat', async () => {
+    const touch = deferred();
+    vi.spyOn(h.state, 'touchWorker').mockImplementation(async () => { await touch.promise; return null; });
+    const pending = call('moe.wait_for_resource', { resourceId: 'box', taskId: 'task-waiter' });
+    connected = false;
+    touch.resolve();
+
+    expect(resultOf(await pending)).toEqual({ granted: false, cancelled: true });
+    expect(h.state.getResource('box')).toBeNull();
+    expect(activeResourceWaiters.size).toBe(0);
+  });
+
+  it('does not acquire a resource after disconnect while awaiting the mutex', async () => {
+    const releaseMutex = deferred();
+    const enteredMutex = deferred();
+    vi.spyOn(h.state, 'touchWorker').mockResolvedValue(null);
+    vi.spyOn(h.state, 'runExclusive').mockImplementation(async fn => {
+      enteredMutex.resolve();
+      await releaseMutex.promise;
+      return fn();
+    });
+    const pending = call('moe.wait_for_resource', { resourceId: 'box', taskId: 'task-waiter' });
+    await enteredMutex.promise;
+    connected = false;
+    releaseMutex.resolve();
+
+    expect(resultOf(await pending)).toEqual({ granted: false, cancelled: true });
+    expect(h.state.getResource('box')).toBeNull();
+  });
+
+  it('does not park after disconnect during resource persistence', async () => {
+    await h.state.acquireResource({ resourceId: 'box', taskId: 'task-holder', workerId: 'worker-holder' });
+    const persisted = deferred();
+    const releasePersist = deferred();
+    const acquire = h.state.acquireResource.bind(h.state);
+    vi.spyOn(h.state, 'acquireResource').mockImplementation(async args => {
+      const result = await acquire(args);
+      persisted.resolve();
+      await releasePersist.promise;
+      return result;
+    });
+    const pending = call('moe.wait_for_resource', { resourceId: 'box', taskId: 'task-waiter' });
+    await persisted.promise;
+    connected = false;
+    releasePersist.resolve();
+
+    expect(resultOf(await pending)).toEqual({ granted: false, cancelled: true });
+    expect(activeResourceWaiters.size).toBe(0);
+    expect(h.state.getResource('box')?.queue.map(entry => entry.taskId)).toEqual(['task-waiter']);
+  });
+});

--- a/packages/moe-daemon/src/server/McpAdapter.ts
+++ b/packages/moe-daemon/src/server/McpAdapter.ts
@@ -120,6 +120,7 @@ export interface JsonRpcResponse {
 
 export interface McpHandleOptions {
   shouldContinue?: () => boolean;
+  onWaiterRegistered?: (toolName: string, workerId: string) => void;
 }
 
 export class McpAdapter {
@@ -169,17 +170,17 @@ export class McpAdapter {
           logger.info('Aborting remaining MCP batch requests because the client disconnected');
           break;
         }
-        const response = await this.handleSingleWithRateLimit(req);
+        const response = await this.handleSingleWithRateLimit(req, options);
         if (response !== null) {
           responses.push(response);
         }
       }
       return responses.length > 0 ? responses : null;
     }
-    return this.handleSingleWithRateLimit(request);
+    return this.handleSingleWithRateLimit(request, options);
   }
 
-  private async handleSingleWithRateLimit(request: unknown): Promise<JsonRpcResponse | null> {
+  private async handleSingleWithRateLimit(request: unknown, options: McpHandleOptions): Promise<JsonRpcResponse | null> {
     const id = this.getRequestId(request);
 
     // A JSON-RPC notification is a valid request with no `id` member; it produces
@@ -204,7 +205,7 @@ export class McpAdapter {
       return this.errorResponse(id, -32600, 'Invalid Request');
     }
 
-    return this.handleSingle(request);
+    return this.handleSingle(request, options);
   }
 
   // An MCP notification is a well-formed request whose method is in the
@@ -234,7 +235,7 @@ export class McpAdapter {
     return typeof id === 'string' || typeof id === 'number' || id === null ? id : null;
   }
 
-  private async handleSingle(request: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+  private async handleSingle(request: JsonRpcRequest, options: McpHandleOptions): Promise<JsonRpcResponse | null> {
     const id: JsonRpcId = request.id ?? null;
 
     try {
@@ -293,7 +294,10 @@ export class McpAdapter {
           // Blocking tools opt out — they'd hold the lock for minutes. The
           // mutex is reentrant, so tools that already call runExclusive
           // internally (claim_next_task, submit_plan, …) are safe to wrap.
-          const invoke = () => tool.handler(params.arguments, this.state);
+          const invoke = () => tool.handler(params.arguments, this.state, {
+            shouldContinue: options.shouldContinue,
+            onWaiterRegistered: workerId => options.onWaiterRegistered?.(tool.name, workerId),
+          });
           const result = tool.blocking ? await invoke() : await this.state.runExclusive(invoke);
           return {
             jsonrpc: '2.0',

--- a/packages/moe-daemon/src/server/WebSocketServer.fixes.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.fixes.test.ts
@@ -75,6 +75,7 @@ describe('WebSocketServer M4 waiter ownership guard', () => {
 
   type Internals = {
     trackMcpWorker(ws: WebSocket, request: unknown): void;
+    registerMcpWaiter(ws: WebSocket, toolName: string, workerId: string): void;
     cleanupMcpWorkers(ws: WebSocket): Promise<void>;
   };
 
@@ -95,6 +96,7 @@ describe('WebSocketServer M4 waiter ownership guard', () => {
       method: 'tools/call',
       params: { name: 'moe.wait_for_task', arguments: { statuses: ['WORKING'], workerId } },
     });
+    internals.registerMcpWaiter(ws1, 'moe.wait_for_task', workerId);
 
     // ws2 is a short-lived connection that reuses the same workerId on a
     // NON-wait tool call (e.g. a one-shot list/touch). It must not own the waiter.
@@ -140,6 +142,7 @@ describe('WebSocketServer M4 waiter ownership guard', () => {
       method: 'tools/call',
       params: { name: 'moe.chat_wait', arguments: { workerId } },
     });
+    internals.registerMcpWaiter(ws1, 'moe.chat_wait', workerId);
 
     const ws2 = {} as WebSocket;
     internals.trackMcpWorker(ws2, {

--- a/packages/moe-daemon/src/server/WebSocketServer.lifecycle.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.lifecycle.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import WebSocket from 'ws';
+import { MoeWebSocketServer } from './WebSocketServer.js';
+import { McpAdapter } from './McpAdapter.js';
+import { StateManager } from '../state/StateManager.js';
+import { activeWaiters } from '../tools/waitForTask.js';
+import { activeChatWaiters } from '../tools/chatWait.js';
+import { activeResourceWaiters } from '../tools/waitForResource.js';
+
+describe('WebSocket lifecycle boundaries', () => {
+  let projectPath: string;
+  let state: StateManager;
+  let httpServer: Server;
+  let server: MoeWebSocketServer;
+  let port: number;
+  const clients: WebSocket[] = [];
+
+  beforeEach(async () => {
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-ws-lifecycle-'));
+    fs.mkdirSync(path.join(projectPath, '.moe'));
+    fs.writeFileSync(path.join(projectPath, '.moe/project.json'), JSON.stringify({
+      id: 'project-lifecycle', schemaVersion: 6, name: 'Lifecycle tests', rootPath: projectPath,
+      settings: { approvalMode: 'CONTROL', agentCommand: 'claude' },
+      globalRails: { techStack: [], forbiddenPatterns: [], requiredPatterns: [], customRules: [] },
+    }));
+    state = new StateManager({ projectPath });
+    await state.load();
+    httpServer = createServer();
+    httpServer.listen(0, '127.0.0.1');
+    await once(httpServer, 'listening');
+    port = (httpServer.address() as { port: number }).port;
+    server = new MoeWebSocketServer(httpServer, state, new McpAdapter(state));
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) client.terminate();
+    await server.close();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    for (const registry of [activeWaiters, activeChatWaiters, activeResourceWaiters]) {
+      for (const waiter of registry.values()) {
+        clearTimeout(waiter.timer);
+        waiter.unsubscribe();
+        waiter.resolve({ cancelled: true });
+      }
+      registry.clear();
+    }
+    vi.restoreAllMocks();
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  async function connect(endpoint: string): Promise<WebSocket> {
+    const client = new WebSocket(`ws://127.0.0.1:${port}/${endpoint}`);
+    clients.push(client);
+    await once(client, 'open');
+    return client;
+  }
+
+  it('cancels all parked RPCs before shutdown completes', async () => {
+    const epic = await state.createEpic({ title: 'Resource owners' });
+    const holder = await state.createTask({ epicId: epic.id, title: 'Holder', status: 'WORKING' });
+    const waiting = await state.createTask({ epicId: epic.id, title: 'Waiting', status: 'WORKING' });
+    await state.updateTask(waiting.id, { assignedWorkerId: 'worker-resource' });
+    await state.acquireResource({ resourceId: 'test-box', taskId: holder.id, workerId: 'worker-holder' });
+    const ws = await connect('mcp');
+    const calls = [
+      { name: 'moe.wait_for_task', arguments: { workerId: 'worker-task', statuses: ['REVIEW'] } },
+      { name: 'moe.chat_wait', arguments: { workerId: 'worker-chat' } },
+      { name: 'moe.wait_for_resource', arguments: {
+        workerId: 'worker-resource', resourceId: 'test-box', taskId: waiting.id,
+      } },
+    ];
+    calls.forEach((params, id) => ws.send(JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/call', params })));
+    await vi.waitFor(() => {
+      expect(activeWaiters.has('worker-task')).toBe(true);
+      expect(activeChatWaiters.has('worker-chat')).toBe(true);
+      expect(activeResourceWaiters.has('worker-resource')).toBe(true);
+    });
+    const waiters = [activeWaiters.get('worker-task')!, activeChatWaiters.get('worker-chat')!,
+      activeResourceWaiters.get('worker-resource')!];
+    const resolves = waiters.map((waiter) => vi.spyOn(waiter, 'resolve'));
+    const unsubscribes = waiters.map((waiter) => vi.spyOn(waiter, 'unsubscribe'));
+
+    await Promise.all([server.close(), server.close()]);
+
+    expect(activeWaiters.size).toBe(0);
+    expect(activeChatWaiters.size).toBe(0);
+    expect(activeResourceWaiters.size).toBe(0);
+    resolves.forEach((resolve) => expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ cancelled: true })));
+    unsubscribes.forEach((unsubscribe) => expect(unsubscribe).toHaveBeenCalledTimes(1));
+    // Socket teardown cancels the RPC, while task-keyed queue membership survives.
+    expect(state.getResource('test-box')?.queue.map((entry) => entry.taskId)).toEqual([waiting.id]);
+  });
+
+  it.each([null, [], 42, 'PING', {}, { type: 1 }].map((payload) => [payload]))('rejects malformed plugin envelopes: %j', async (payload) => {
+    const ws = await connect('ws');
+    const messages: unknown[] = [];
+    ws.on('message', (raw) => messages.push(JSON.parse(raw.toString())));
+    ws.send(JSON.stringify(payload));
+    await vi.waitFor(() => expect(messages).toContainEqual({ type: 'ERROR', message: 'Invalid message envelope' }));
+
+    ws.send(JSON.stringify({ type: 'PING' }));
+    await vi.waitFor(() => expect(messages).toContainEqual({ type: 'PONG' }));
+  });
+
+  it('does not register a waiter when shutdown finishes during heartbeat persistence', async () => {
+    let resumeHeartbeat!: () => void;
+    let heartbeatStarted!: () => void;
+    const heartbeatGate = new Promise<void>((resolve) => { resumeHeartbeat = resolve; });
+    const started = new Promise<void>((resolve) => { heartbeatStarted = resolve; });
+    vi.spyOn(state, 'touchWorker').mockImplementation(async () => {
+      heartbeatStarted();
+      await heartbeatGate;
+      return null;
+    });
+    const handle = vi.spyOn(McpAdapter.prototype, 'handle');
+    const ws = await connect('mcp');
+    ws.send(JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'moe.wait_for_task', arguments: { workerId: 'worker-slow', statuses: ['REVIEW'] } },
+    }));
+    try {
+      await started;
+      await server.close();
+    } finally {
+      resumeHeartbeat();
+    }
+    let settled = false;
+    void handle.mock.results[0].value.then(() => { settled = true; });
+    await vi.waitFor(() => expect(settled).toBe(true));
+    expect(activeWaiters.has('worker-slow')).toBe(false);
+  });
+
+  it('refuses new connections while flushing the shutdown notification', async () => {
+    await connect('ws');
+    const handle = vi.spyOn(McpAdapter.prototype, 'handle');
+    const closing = server.close();
+    const lateClient = new WebSocket(`ws://127.0.0.1:${port}/mcp`);
+    clients.push(lateClient);
+    lateClient.on('open', () => lateClient.send(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })));
+    const codes: number[] = [];
+    lateClient.on('close', (code) => codes.push(code));
+
+    await closing;
+
+    expect(handle).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(codes).toEqual([1001]));
+  });
+});

--- a/packages/moe-daemon/src/server/WebSocketServer.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.test.ts
@@ -788,6 +788,7 @@ describe('MoeWebSocketServer Integration', () => {
       const fakeWs = {} as WebSocket;
       const internals = wsServer as unknown as {
         trackMcpWorker(ws: WebSocket, request: unknown): void;
+        registerMcpWaiter(ws: WebSocket, toolName: string, workerId: string): void;
         cleanupMcpWorkers(ws: WebSocket): Promise<void>;
         mcpWorkerMap: Map<WebSocket, Set<string>>;
       };
@@ -809,6 +810,9 @@ describe('MoeWebSocketServer Integration', () => {
       ]);
 
       expect(internals.mcpWorkerMap.get(fakeWs)).toEqual(new Set(['worker-batch-wait', 'worker-batch-chat']));
+      // Publishing the waiters, rather than merely parsing the batch, owns them.
+      internals.registerMcpWaiter(fakeWs, 'moe.wait_for_task', 'worker-batch-wait');
+      internals.registerMcpWaiter(fakeWs, 'moe.chat_wait', 'worker-batch-chat');
 
       await internals.cleanupMcpWorkers(fakeWs);
 

--- a/packages/moe-daemon/src/server/WebSocketServer.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.ts
@@ -140,8 +140,8 @@ export class MoeWebSocketServer {
   // short-lived second /mcp connection that reuses a parked id must NOT cancel
   // the live waiter the FIRST connection registered. We record which ws issued
   // the call that (re)registered each waiter and only cancel on disconnect when
-  // the closing ws still owns it. Overwritten whenever a new wait/chat_wait call
-  // re-registers the waiter (the tool itself cancels+replaces the prior entry).
+  // the closing ws still owns it. Ownership changes only after registration:
+  // rejected calls and undispatched batch entries never own a prior waiter.
   private waiterOwners = new Map<string, WebSocket>();
   private chatWaiterOwners = new Map<string, WebSocket>();
   private resourceWaiterOwners = new Map<string, WebSocket>();
@@ -195,6 +195,10 @@ export class MoeWebSocketServer {
   }
 
   private onConnection(ws: WebSocket, req: IncomingMessage): void {
+    if (this.isClosed) {
+      ws.close(1001, 'Server shutting down');
+      return;
+    }
     const url = req.url || '/';
     if (url.startsWith('/mcp')) {
       this.mcpClients.add(ws);
@@ -258,7 +262,13 @@ export class MoeWebSocketServer {
   private async handlePluginMessage(ws: WebSocket, raw: string): Promise<void> {
     let message: PluginMessage;
     try {
-      message = JSON.parse(raw) as PluginMessage;
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)
+        || typeof (parsed as { type?: unknown }).type !== 'string') {
+        this.safeSend(ws, JSON.stringify({ type: 'ERROR', message: 'Invalid message envelope' }));
+        return;
+      }
+      message = parsed as PluginMessage;
     } catch {
       this.safeSend(ws, JSON.stringify({ type: 'ERROR', message: 'Invalid JSON' }));
       return;
@@ -959,7 +969,8 @@ export class MoeWebSocketServer {
       const request = JSON.parse(raw);
       this.trackMcpWorker(ws, request);
       const response = await this.mcpAdapter.handle(request, {
-        shouldContinue: () => this.mcpClients.has(ws) && ws.readyState === WebSocket.OPEN,
+        shouldContinue: () => !this.isClosed && this.mcpClients.has(ws) && ws.readyState === WebSocket.OPEN,
+        onWaiterRegistered: (toolName, workerId) => this.registerMcpWaiter(ws, toolName, workerId),
       });
       if (response !== null) {
         this.safeSend(ws, JSON.stringify(response));
@@ -1005,13 +1016,10 @@ export class MoeWebSocketServer {
       this.mcpWorkerMap.set(ws, workerIds);
     }
     workerIds.add(workerId);
+  }
 
-    // Record which ws owns the (about to be re-registered) waiter for this
-    // workerId. wait_for_task / chat_wait cancel + replace any prior waiter for
-    // the same id, so the issuing ws becomes the sole owner. cleanupMcpWorkers
-    // uses this to avoid cancelling a live waiter that a different connection
-    // owns when a short-lived ws reuses the same workerId.
-    const toolName = (params as { name?: unknown }).name;
+  /** Transfer ownership only when a tool actually publishes its new waiter. */
+  private registerMcpWaiter(ws: WebSocket, toolName: string, workerId: string): void {
     if (toolName === 'moe.wait_for_task') {
       this.waiterOwners.set(workerId, ws);
     } else if (toolName === 'moe.chat_wait') {
@@ -1153,6 +1161,14 @@ export class MoeWebSocketServer {
         }
       }
       for (const client of this.mcpClients) {
+        // Stop queued batch calls before resolving waiters. Preserve connection
+        // ownership until cleanup has cancelled every parked RPC on this socket.
+        this.mcpClients.delete(client);
+        try {
+          await this.cleanupMcpWorkers(client);
+        } catch (error) {
+          logger.warn({ error }, 'Error cancelling MCP waiters during shutdown');
+        }
         try {
           client.close(1000, 'Server shutting down');
         } catch (error) {
@@ -1168,6 +1184,7 @@ export class MoeWebSocketServer {
       this.mcpWorkerMap.clear();
       this.waiterOwners.clear();
       this.chatWaiterOwners.clear();
+      this.resourceWaiterOwners.clear();
 
       await new Promise<void>((resolve, reject) => {
         this.wss.close((err) => {

--- a/packages/moe-daemon/src/server/WebSocketServer.waiter-ownership.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.waiter-ownership.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { once } from 'node:events';
+import WebSocket from 'ws';
+import { ToolTestHarness } from '../tools/toolTestHarness.js';
+import { activeWaiters } from '../tools/waitForTask.js';
+import { activeChatWaiters } from '../tools/chatWait.js';
+import { activeResourceWaiters } from '../tools/waitForResource.js';
+import { McpAdapter } from './McpAdapter.js';
+import { MoeWebSocketServer } from './WebSocketServer.js';
+
+const cases = [
+  { name: 'moe.wait_for_task', registry: activeWaiters, valid: { statuses: ['REVIEW'] }, invalid: {} },
+  { name: 'moe.chat_wait', registry: activeChatWaiters, valid: {}, invalid: { sinceId: 42 } },
+  { name: 'moe.wait_for_resource', registry: activeResourceWaiters,
+    valid: { resourceId: 'box', taskId: 'task-waiter' }, invalid: { resourceId: 'box' } },
+];
+
+describe('MCP waiter registration ownership', () => {
+  const h = new ToolTestHarness();
+  const clients: WebSocket[] = [];
+  let http: Server;
+  let server: MoeWebSocketServer;
+  let port: number;
+
+  beforeEach(async () => {
+    h.init();
+    h.setupMoeFolder();
+    h.createEpic();
+    h.createTask({ id: 'task-holder', status: 'WORKING', assignedWorkerId: 'worker-holder' });
+    h.createTask({ id: 'task-waiter', status: 'WORKING', assignedWorkerId: 'worker-waiter' });
+    await h.state.load();
+    await h.state.acquireResource({ resourceId: 'box', taskId: 'task-holder', workerId: 'worker-holder' });
+    http = createServer();
+    http.listen(0, '127.0.0.1');
+    await once(http, 'listening');
+    port = (http.address() as { port: number }).port;
+    server = new MoeWebSocketServer(http, h.state, new McpAdapter(h.state));
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) client.terminate();
+    await server.close();
+    await new Promise<void>(resolve => http.close(() => resolve()));
+    for (const { registry } of cases) {
+      for (const waiter of registry.values()) {
+        clearTimeout(waiter.timer);
+        waiter.unsubscribe();
+        waiter.resolve({ cancelled: true });
+      }
+      registry.clear();
+    }
+    vi.restoreAllMocks();
+    h.cleanup();
+  });
+
+  async function connect(): Promise<WebSocket> {
+    const client = new WebSocket(`ws://127.0.0.1:${port}/mcp`);
+    clients.push(client);
+    await once(client, 'open');
+    return client;
+  }
+
+  function request(name: string, args: Record<string, unknown>, id = 1) {
+    return { jsonrpc: '2.0', id, method: 'tools/call',
+      params: { name, arguments: { workerId: 'worker-waiter', timeoutMs: 10000, ...args } } };
+  }
+
+  async function disconnect(client: WebSocket): Promise<void> {
+    const cleanup = vi.spyOn(server as unknown as { cleanupMcpWorkers(ws: WebSocket): Promise<void> },
+      'cleanupMcpWorkers');
+    const previousCalls = cleanup.mock.calls.length;
+    const closed = once(client, 'close');
+    client.close();
+    await closed;
+    await vi.waitFor(() => expect(cleanup.mock.calls.length).toBeGreaterThan(previousCalls));
+  }
+
+  it.each(cases)('rejected $name replacement cannot cancel the original socket waiter', async entry => {
+    const original = await connect();
+    original.send(JSON.stringify(request(entry.name, entry.valid)));
+    await vi.waitFor(() => expect(entry.registry.has('worker-waiter')).toBe(true));
+    const waiter = entry.registry.get('worker-waiter');
+    const rejected = await connect();
+    const response = once(rejected, 'message');
+    rejected.send(JSON.stringify(request(entry.name, entry.invalid)));
+    const [raw] = await response;
+    expect(JSON.parse(raw.toString()).error.code).toBe(-32602);
+
+    await disconnect(rejected);
+    expect(entry.registry.get('worker-waiter')).toBe(waiter);
+    await disconnect(original);
+    expect(entry.registry.has('worker-waiter')).toBe(false);
+  });
+
+  it.each(cases)('registered $name replacement becomes the sole socket owner', async entry => {
+    const original = await connect();
+    original.send(JSON.stringify(request(entry.name, entry.valid)));
+    await vi.waitFor(() => expect(entry.registry.has('worker-waiter')).toBe(true));
+    const oldWaiter = entry.registry.get('worker-waiter');
+    const replacement = await connect();
+    replacement.send(JSON.stringify(request(entry.name, entry.valid)));
+    await vi.waitFor(() => {
+      expect(entry.registry.has('worker-waiter')).toBe(true);
+      expect(entry.registry.get('worker-waiter')).not.toBe(oldWaiter);
+    });
+    const newWaiter = entry.registry.get('worker-waiter');
+
+    await disconnect(original);
+    expect(entry.registry.get('worker-waiter')).toBe(newWaiter);
+    await disconnect(replacement);
+    expect(entry.registry.has('worker-waiter')).toBe(false);
+  });
+
+  it('an undispatched batch request cannot steal a live socket waiter', async () => {
+    const original = await connect();
+    original.send(JSON.stringify(request('moe.wait_for_task', { statuses: ['REVIEW'] })));
+    await vi.waitFor(() => expect(activeWaiters.has('worker-waiter')).toBe(true));
+    const waiter = activeWaiters.get('worker-waiter');
+    const batch = await connect();
+    batch.send(JSON.stringify([
+      request('moe.chat_wait', { workerId: 'worker-batch' }),
+      request('moe.wait_for_task', { statuses: ['REVIEW'] }, 2),
+    ]));
+    await vi.waitFor(() => expect(activeChatWaiters.has('worker-batch')).toBe(true));
+
+    await disconnect(batch);
+    expect(activeWaiters.get('worker-waiter')).toBe(waiter);
+    expect(activeChatWaiters.has('worker-batch')).toBe(false);
+    await disconnect(original);
+    expect(activeWaiters.has('worker-waiter')).toBe(false);
+  });
+});

--- a/packages/moe-daemon/src/state/resourceStore.durability.test.ts
+++ b/packages/moe-daemon/src/state/resourceStore.durability.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { ToolTestHarness } from '../tools/toolTestHarness.js';
+import { DEFAULT_MAX_LEASE_MS } from './resourceStore.js';
+import { StateManager } from './StateManager.js';
+import type { ResourceState } from '../types/schema.js';
+
+describe('resourceStore persistence failures', () => {
+  const h = new ToolTestHarness();
+
+  beforeEach(async () => {
+    h.init();
+    h.setupMoeFolder({ schemaVersion: 6 });
+    h.createEpic();
+    h.createTask({ id: 'task-holder', status: 'WORKING', assignedWorkerId: 'worker-holder' });
+    h.createTask({
+      id: 'task-waiter', status: 'BLOCKED', assignedWorkerId: null,
+      blockedResourceId: 'box', blockedFromStatus: 'WORKING',
+      blockedReason: 'Waiting for box', blockedAt: new Date().toISOString(),
+    });
+    await h.state.load();
+    vi.spyOn(h.state, 'postToGeneral').mockResolvedValue();
+    vi.spyOn(h.state, 'postToRoleChannel').mockResolvedValue();
+    vi.spyOn(h.state, 'postSystemMessage').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    h.state.clearEmitter();
+    vi.restoreAllMocks();
+    h.cleanup();
+  });
+
+  const holder = { resourceId: 'box', taskId: 'task-holder', workerId: 'worker-holder' };
+  const waiter = { resourceId: 'box', taskId: 'task-waiter', workerId: 'worker-waiter' };
+
+  function readResource(): ResourceState {
+    return JSON.parse(fs.readFileSync(path.join(h.moePath, 'resources', 'box.json'), 'utf8'));
+  }
+
+  function failNextResourceWrite(): void {
+    const writeEntity = h.state.writeEntity.bind(h.state);
+    let failed = false;
+    vi.spyOn(h.state, 'writeEntity').mockImplementation(async (kind, id, entity) => {
+      if (kind === 'resources' && !failed) {
+        failed = true;
+        throw new Error('Injected resource write failure');
+      }
+      await writeEntity(kind, id, entity);
+    });
+  }
+
+  it('does not expose a new resource when its initial lease write fails', async () => {
+    failNextResourceWrite();
+    await expect(h.state.acquireResource(holder)).rejects.toThrow('Injected resource write failure');
+    expect(h.state.getResource('box')).toBeNull();
+    expect(fs.existsSync(path.join(h.moePath, 'resources', 'box.json'))).toBe(false);
+  });
+
+  it('preserves the persisted lease when renewal fails', async () => {
+    await h.state.acquireResource(holder);
+    const before = readResource();
+    failNextResourceWrite();
+    await expect(h.state.acquireResource({ ...holder, note: 'renewed', workerId: 'worker-successor' }))
+      .rejects.toThrow('Injected resource write failure');
+    expect(h.state.getResource('box')).toEqual(before);
+    expect(readResource()).toEqual(before);
+  });
+
+  it('does not announce or retain a queue entry that failed to persist', async () => {
+    await h.state.acquireResource(holder);
+    const activity = vi.spyOn(h.state, 'appendActivity');
+    failNextResourceWrite();
+    await expect(h.state.acquireResource(waiter)).rejects.toThrow('Injected resource write failure');
+    expect(h.state.getResource('box')!.queue).toEqual([]);
+    expect(readResource().queue).toEqual([]);
+    expect(activity.mock.calls.filter(([event]) => event === 'RESOURCE_QUEUED')).toEqual([]);
+  });
+
+  it('keeps a lease held when release fails to persist', async () => {
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+    const before = readResource();
+    failNextResourceWrite();
+    await expect(h.state.releaseResource(holder)).rejects.toThrow('Injected resource write failure');
+    expect(h.state.getResource('box')).toEqual(before);
+    expect(readResource()).toEqual(before);
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('BLOCKED');
+  });
+
+  it('keeps an expired lease in memory when the reaper write fails', async () => {
+    await h.state.acquireResource(holder);
+    const before = readResource();
+    failNextResourceWrite();
+    await expect(h.state.reapResources(Date.now() + DEFAULT_MAX_LEASE_MS + 1000))
+      .rejects.toThrow('Injected resource write failure');
+    expect(h.state.getResource('box')).toEqual(before);
+    expect(readResource()).toEqual(before);
+  });
+
+  async function prepareFreeCapacity(): Promise<void> {
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+    // Reproduce the durable state between a successful release and its grant.
+    const resource = { ...readResource(), holders: [] };
+    await h.state.writeEntity('resources', resource.id, resource);
+    h.state.resources.set(resource.id, resource);
+  }
+
+  it('does not unblock or announce a waiter until its grant is durable', async () => {
+    await prepareFreeCapacity();
+    const activity = vi.spyOn(h.state, 'appendActivity');
+    failNextResourceWrite();
+    await expect(h.state.grantNextLeases('box')).rejects.toThrow('Injected resource write failure');
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('BLOCKED');
+    expect(h.state.getResource('box')!.holders).toEqual([]);
+    expect(readResource().holders).toEqual([]);
+    expect(activity.mock.calls.filter(([event]) => event === 'RESOURCE_GRANTED')).toEqual([]);
+    expect(h.state.postToGeneral).not.toHaveBeenCalled();
+  });
+
+  it('persists a grant before publishing its task unblock event', async () => {
+    await prepareFreeCapacity();
+    const durableOwnersAtUnblock: string[][] = [];
+    h.state.setEmitter((event) => {
+      if (event.type === 'TASK_UPDATED' && event.payload.id === waiter.taskId && event.payload.status === 'WORKING') {
+        durableOwnersAtUnblock.push(readResource().holders.map((lease) => lease.taskId));
+      }
+    });
+    await h.state.grantNextLeases('box');
+    expect(durableOwnersAtUnblock).toEqual([[waiter.taskId]]);
+  });
+
+  async function restartDaemon(): Promise<void> {
+    h.state.clearEmitter();
+    h.state = new StateManager({ projectPath: h.testDir });
+    await h.state.load();
+    vi.spyOn(h.state, 'postToGeneral').mockResolvedValue();
+    vi.spyOn(h.state, 'postToRoleChannel').mockResolvedValue();
+    vi.spyOn(h.state, 'postSystemMessage').mockResolvedValue();
+  }
+
+  it.each([false, true])('retries a failed grant when nothing expired (restart=%s)', async (restart) => {
+    await prepareFreeCapacity();
+    failNextResourceWrite();
+    await expect(h.state.grantNextLeases('box')).rejects.toThrow('Injected resource write failure');
+    if (restart) await restartDaemon();
+    expect(await h.state.reapResources()).toBe(0);
+    expect(readResource().holders.map((lease) => lease.taskId)).toEqual([waiter.taskId]);
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('WORKING');
+  });
+
+  it.each([false, true])('retries an unblock after its task write failed (restart=%s)', async (restart) => {
+    await prepareFreeCapacity();
+    const writeEntity = h.state.writeEntity.bind(h.state);
+    let failed = false;
+    vi.spyOn(h.state, 'writeEntity').mockImplementation(async (kind, id, entity) => {
+      if (kind === 'tasks' && id === waiter.taskId && !failed) {
+        failed = true;
+        throw new Error('Injected task write failure');
+      }
+      await writeEntity(kind, id, entity);
+    });
+    await h.state.grantNextLeases('box');
+    expect(readResource().holders.map((lease) => lease.taskId)).toEqual([waiter.taskId]);
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('BLOCKED');
+    if (restart) await restartDaemon();
+    expect(await h.state.reapResources()).toBe(0);
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('WORKING');
+    expect(h.state.getTask(waiter.taskId)!.blockedResourceId).toBeNull();
+  });
+
+  it.each(['1970-01-01T00:00:00.000Z', 'invalid'])('does not resume a holder without a valid unexpired lease (%s)', async (expiresAt) => {
+    await h.state.acquireResource(waiter);
+    const resource = readResource();
+    resource.holders[0].expiresAt = expiresAt;
+    await h.state.writeEntity('resources', resource.id, resource);
+    await restartDaemon();
+
+    await h.state.grantNextLeases('box');
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('BLOCKED');
+    expect(h.state.postToGeneral).not.toHaveBeenCalled();
+  });
+});

--- a/packages/moe-daemon/src/state/resourceStore.lifecycle.test.ts
+++ b/packages/moe-daemon/src/state/resourceStore.lifecycle.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { ToolTestHarness } from '../tools/toolTestHarness.js';
+import type { ResourceState, TaskStatus, Worker } from '../types/schema.js';
+
+describe('resourceStore lifecycle reconciliation', () => {
+  const h = new ToolTestHarness();
+  const holder = { resourceId: 'box', taskId: 'task-holder', workerId: 'worker-holder' };
+  const waiter = { resourceId: 'box', taskId: 'task-waiter', workerId: 'worker-waiter' };
+
+  beforeEach(() => {
+    h.init();
+    h.setupMoeFolder({ schemaVersion: 6 });
+    h.createEpic();
+    h.createTask({ id: holder.taskId, status: 'WORKING', assignedWorkerId: holder.workerId });
+    h.createTask({
+      id: waiter.taskId, status: 'BLOCKED', assignedWorkerId: waiter.workerId,
+      blockedResourceId: 'box', blockedFromStatus: 'WORKING',
+      blockedReason: 'Waiting for box', blockedAt: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    h.state.clearEmitter();
+    vi.restoreAllMocks();
+    h.cleanup();
+  });
+
+  async function loadState(): Promise<void> {
+    await h.state.load();
+    vi.spyOn(h.state, 'postToGeneral').mockResolvedValue();
+    vi.spyOn(h.state, 'postToRoleChannel').mockResolvedValue();
+    vi.spyOn(h.state, 'postSystemMessage').mockResolvedValue();
+  }
+
+  function readResource(): ResourceState {
+    return JSON.parse(fs.readFileSync(path.join(h.moePath, 'resources', 'box.json'), 'utf8'));
+  }
+
+  const inactiveStatuses: Array<TaskStatus | 'deleted'> = ['DONE', 'ARCHIVED', 'BACKLOG', 'AWAITING_APPROVAL', 'deleted'];
+  it.each(inactiveStatuses)('normal release skips a queued task that became %s', async (status) => {
+    h.createTask({ id: 'task-stale', status: 'WORKING', priority: 'CRITICAL' });
+    await loadState();
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource({ resourceId: 'box', taskId: 'task-stale', workerId: 'worker-stale' });
+    await h.state.acquireResource(waiter);
+    if (status === 'deleted') await h.state.deleteTask('task-stale');
+    else await h.state.updateTask('task-stale', { status });
+
+    const result = await h.state.releaseResource(holder);
+    expect(result.granted.map((lease) => lease.taskId)).toEqual([waiter.taskId]);
+    expect(readResource().holders.map((lease) => lease.taskId)).toEqual([waiter.taskId]);
+    expect(readResource().queue).toEqual([]);
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('WORKING');
+  });
+
+  it('persists queue cleanup when every waiter became inactive', async () => {
+    await loadState();
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+    await h.state.updateTask(waiter.taskId, { status: 'ARCHIVED' });
+
+    const result = await h.state.releaseResource(holder);
+    expect(result.granted).toEqual([]);
+    expect(readResource().holders).toEqual([]);
+    expect(readResource().queue).toEqual([]);
+  });
+
+  it('returns a resource task to the claim pool after its parked worker timed out', async () => {
+    h.createWorker({
+      id: waiter.workerId, status: 'BLOCKED', currentTaskId: waiter.taskId,
+      lastActivityAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    });
+    await loadState();
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+    await h.state.checkBlockedTimeouts();
+    expect(h.state.getTask(waiter.taskId)!.status).toBe('BLOCKED');
+    expect(h.state.getWorker(waiter.workerId)!.status).toBe('IDLE');
+    expect(h.state.getWorker(waiter.workerId)!.currentTaskId).toBeNull();
+
+    await h.state.releaseResource(holder);
+    const restored = h.state.getTask(waiter.taskId)!;
+    expect(restored.status).toBe('WORKING');
+    expect(restored.assignedWorkerId).toBeNull();
+    expect(h.state.isTaskClaimable(restored)).toBe(true);
+    expect(readResource().holders.map((lease) => lease.taskId)).toEqual([waiter.taskId]);
+  });
+
+  const absentOwners: Array<{ name: string; overrides?: Partial<Worker> }> = [
+    { name: 'missing' },
+    { name: 'dead', overrides: { status: 'DEAD', currentTaskId: waiter.taskId } },
+    { name: 'idle with no task', overrides: { status: 'IDLE', currentTaskId: null } },
+    { name: 'working elsewhere', overrides: { status: 'CODING', currentTaskId: holder.taskId } },
+  ];
+  it.each(absentOwners)('does not restore a resource task onto an owner who is $name', async ({ overrides }) => {
+    if (overrides) h.createWorker({ id: waiter.workerId, ...overrides });
+    await loadState();
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+
+    await h.state.releaseResource(holder);
+    const restored = h.state.getTask(waiter.taskId)!;
+    expect(restored.assignedWorkerId).toBeNull();
+    expect(h.state.isTaskClaimable(restored)).toBe(true);
+    if (overrides) expect(h.state.getWorker(waiter.workerId)!.currentTaskId).toBe(overrides.currentTaskId);
+  });
+
+  it('preserves a quiet parked worker that still points at the resource task', async () => {
+    h.createWorker({
+      id: waiter.workerId, status: 'BLOCKED', currentTaskId: waiter.taskId,
+      lastActivityAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    });
+    await loadState();
+    await h.state.acquireResource(holder);
+    await h.state.acquireResource(waiter);
+
+    await h.state.releaseResource(holder);
+    const restored = h.state.getTask(waiter.taskId)!;
+    expect(restored.status).toBe('WORKING');
+    expect(restored.assignedWorkerId).toBe(waiter.workerId);
+    expect(h.state.getWorker(waiter.workerId)!.currentTaskId).toBe(waiter.taskId);
+    expect(h.state.isTaskClaimable(restored)).toBe(false);
+  });
+});

--- a/packages/moe-daemon/src/state/resourceStore.ts
+++ b/packages/moe-daemon/src/state/resourceStore.ts
@@ -52,6 +52,11 @@ const RESOURCE_ELIGIBLE_STATUSES = new Set<TaskStatus>([
   'BLOCKED',
 ]);
 
+function isResourceTaskEligible(state: StateManager, taskId: string): boolean {
+  const task = state.tasks.get(taskId);
+  return !!task && RESOURCE_ELIGIBLE_STATUSES.has(task.status);
+}
+
 export interface ResourceConfig {
   capacity: number;
   maxLeaseMs: number;
@@ -78,13 +83,20 @@ export function getResource(state: StateManager, resourceId: string): ResourceSt
   return state.resources.get(resourceId) ?? null;
 }
 
+/** Mutations use private copies so failed writes cannot alter the published state. */
+function copyResource(resource: ResourceState): ResourceState {
+  return {
+    ...resource,
+    holders: resource.holders.map((lease) => ({ ...lease })),
+    queue: resource.queue.map((entry) => ({ ...entry })),
+  };
+}
+
 function getOrCreateResource(state: StateManager, resourceId: string): ResourceState {
   const existing = state.resources.get(resourceId);
-  if (existing) return existing;
+  if (existing) return copyResource(existing);
   const now = new Date().toISOString();
-  const fresh: ResourceState = { id: resourceId, holders: [], queue: [], createdAt: now, updatedAt: now };
-  state.resources.set(resourceId, fresh);
-  return fresh;
+  return { id: resourceId, holders: [], queue: [], createdAt: now, updatedAt: now };
 }
 
 async function persistResource(state: StateManager, resource: ResourceState): Promise<void> {
@@ -179,15 +191,18 @@ export async function acquireResource(state: StateManager, params: AcquireParams
   }
 
   let entry = resource.queue.find((q) => q.taskId === taskId);
+  const newlyQueued = !entry;
   if (entry) {
     entry.workerId = workerId;
     if (params.note !== undefined) entry.note = params.note;
   } else {
     entry = { taskId, workerId, note: params.note, requestedAt: nowIso };
     resource.queue.push(entry);
-    state.appendActivity('RESOURCE_QUEUED', { resourceId, taskId, workerId, note: params.note });
   }
   await persistResource(state, resource);
+  if (newlyQueued) {
+    state.appendActivity('RESOURCE_QUEUED', { resourceId, taskId, workerId, note: params.note });
+  }
   const position = sortedQueue(state, resource.queue).findIndex((q) => q.taskId === taskId) + 1;
   return {
     granted: false,
@@ -219,8 +234,9 @@ export interface ReleaseResourceResult {
  * no-op (idempotent), not an error — release paths run from exit traps.
  */
 export async function releaseResource(state: StateManager, params: ReleaseParams): Promise<ReleaseResourceResult> {
-  const resource = state.resources.get(params.resourceId);
-  if (!resource) return { released: [], removedFromQueue: [], granted: [] };
+  const persisted = state.resources.get(params.resourceId);
+  if (!persisted) return { released: [], removedFromQueue: [], granted: [] };
+  const resource = copyResource(persisted);
 
   // Leases are task-keyed so they survive CLI respawns and the restart worker
   // purge — which means the RELEASE path must too: the task's CURRENT assignee
@@ -266,10 +282,15 @@ export async function releaseResource(state: StateManager, params: ReleaseParams
  * (non-BLOCKED) held task and relaunches the CLI.
  */
 export async function grantNextLeases(state: StateManager, resourceId: string): Promise<ResourceLease[]> {
-  const resource = state.resources.get(resourceId);
-  if (!resource) return [];
+  const persisted = state.resources.get(resourceId);
+  if (!persisted) return [];
+  const resource = copyResource(persisted);
   const config = resolveResourceConfig(state, resourceId);
   const granted: ResourceLease[] = [];
+  // A queued task can finish, be parked, or be deleted before its turn.
+  // Every grant path must recheck eligibility, not just the periodic reaper.
+  resource.queue = resource.queue.filter((entry) => isResourceTaskEligible(state, entry.taskId));
+  const queueCleaned = resource.queue.length !== persisted.queue.length;
 
   while (resource.holders.length < config.capacity && resource.queue.length > 0) {
     const next = sortedQueue(state, resource.queue)[0];
@@ -284,44 +305,60 @@ export async function grantNextLeases(state: StateManager, resourceId: string): 
     };
     resource.holders.push(lease);
     granted.push(lease);
-    state.appendActivity('RESOURCE_GRANTED', { resourceId, taskId: lease.taskId, workerId: lease.workerId });
-
-    const task = state.tasks.get(lease.taskId);
-    if (task && task.status === 'BLOCKED' && task.blockedResourceId === resourceId) {
-      const restored: TaskStatus = task.blockedFromStatus ?? 'WORKING';
-      try {
-        // assignedWorkerId passed explicitly: updateTask would otherwise clear
-        // the assignment on the status change, and the un-blocked task must
-        // return to the SAME parked worker (or stay unassigned-and-claimable
-        // if the worker was purged meanwhile).
-        await state.updateTask(task.id, {
-          status: restored,
-          assignedWorkerId: task.assignedWorkerId,
-          blockedReason: null,
-          blockedResourceId: null,
-          blockedOnTaskIds: null,
-          blockedFromStatus: null,
-          blockedAt: null,
-        }, 'TASK_UNBLOCKED');
-        const msg = `🟢 Resource ${resourceId} granted to ${task.id} (${lease.workerId}); task un-blocked → ${restored}.`;
-        try { await state.postSystemMessage(task.id, msg); } catch { /* best-effort */ }
-        try { await state.postToGeneral(msg); } catch { /* best-effort */ }
-      } catch (err) {
-        logger.warn({ resourceId, taskId: task.id, error: err }, 'grantNextLeases: failed to un-block task');
-      }
-    } else {
-      // Lease granted while the task kept working elsewhere (queued early, no
-      // report_blocked yet) — tell the channel so the holder finds out even if
-      // it never re-polls acquire_resource.
-      const msg = `🟢 Resource ${resourceId} granted to ${lease.taskId} (${lease.workerId}).`;
-      try { await state.postToGeneral(msg); } catch { /* best-effort */ }
-    }
   }
 
-  if (granted.length > 0) {
+  // The lease is the authority to resume work. Persist it before publishing
+  // any grant or task transition, so a crash cannot resume an unleased task.
+  if (granted.length > 0 || queueCleaned) {
     await persistResource(state, resource);
   }
+  for (const lease of granted) {
+    state.appendActivity('RESOURCE_GRANTED', { resourceId, taskId: lease.taskId, workerId: lease.workerId });
+  }
+  // Reconcile existing holders too: a crash or failed task write can leave a
+  // durable lease with its task still BLOCKED. This retry survives reloads.
+  for (const lease of resource.holders) {
+    await resumeResourceHolder(state, resourceId, lease, granted.includes(lease));
+  }
   return granted;
+}
+
+async function resumeResourceHolder(
+  state: StateManager, resourceId: string, lease: ResourceLease, newlyGranted: boolean
+): Promise<void> {
+  // Direct grant retries can run before the expiry sweep. A persisted lease
+  // authorizes resumption only while its expiry is valid and still future.
+  const expiresMs = Date.parse(lease.expiresAt);
+  if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) return;
+  const task = state.tasks.get(lease.taskId);
+  if (task && task.status === 'BLOCKED' && task.blockedResourceId === resourceId) {
+    const restored: TaskStatus = task.blockedFromStatus ?? 'WORKING';
+    // Mirror dependency-unblock: a timed-out or repurposed worker no longer
+    // owns this hold. Restoring its stale assignment would strand the task.
+    const owner = task.assignedWorkerId ? state.getWorker(task.assignedWorkerId) : null;
+    const restoreTo = owner && owner.status !== 'DEAD' && owner.currentTaskId === task.id ? owner.id : null;
+    try {
+      // Preserve a valid parked owner explicitly; otherwise return the task
+      // unassigned so a successor can claim it and its task-keyed lease.
+      await state.updateTask(task.id, {
+        status: restored,
+        assignedWorkerId: restoreTo,
+        blockedReason: null,
+        blockedResourceId: null,
+        blockedOnTaskIds: null,
+        blockedFromStatus: null,
+        blockedAt: null,
+      }, 'TASK_UNBLOCKED');
+      const msg = `🟢 Resource ${resourceId} granted to ${task.id} (${lease.workerId}); task un-blocked → ${restored}.`;
+      try { await state.postSystemMessage(task.id, msg); } catch { /* best-effort */ }
+      try { await state.postToGeneral(msg); } catch { /* best-effort */ }
+    } catch (err) {
+      logger.warn({ resourceId, taskId: task.id, error: err }, 'grantNextLeases: failed to un-block task');
+    }
+  } else if (newlyGranted) {
+    const msg = `🟢 Resource ${resourceId} granted to ${lease.taskId} (${lease.workerId}).`;
+    try { await state.postToGeneral(msg); } catch { /* best-effort */ }
+  }
 }
 
 /**
@@ -335,12 +372,12 @@ export async function grantNextLeases(state: StateManager, resourceId: string): 
  */
 export async function reapResources(state: StateManager, nowMs: number = Date.now()): Promise<number> {
   let reaped = 0;
-  for (const resource of state.resources.values()) {
+  for (const persisted of state.resources.values()) {
+    const resource = copyResource(persisted);
     const expiredLeases: ResourceLease[] = [];
     const orphanedLeases: ResourceLease[] = [];
     for (const lease of resource.holders) {
-      const task = state.tasks.get(lease.taskId);
-      if (!task || !RESOURCE_ELIGIBLE_STATUSES.has(task.status)) {
+      if (!isResourceTaskEligible(state, lease.taskId)) {
         orphanedLeases.push(lease);
         continue;
       }
@@ -349,19 +386,17 @@ export async function reapResources(state: StateManager, nowMs: number = Date.no
         expiredLeases.push(lease);
       }
     }
-    const dropQueue = resource.queue.filter((q) => {
-      const task = state.tasks.get(q.taskId);
-      return !task || !RESOURCE_ELIGIBLE_STATUSES.has(task.status);
-    });
+    const dropQueue = resource.queue.filter((q) => !isResourceTaskEligible(state, q.taskId));
 
-    if (expiredLeases.length === 0 && orphanedLeases.length === 0 && dropQueue.length === 0) continue;
-
-    resource.holders = resource.holders.filter(
-      (h) => !expiredLeases.includes(h) && !orphanedLeases.includes(h)
-    );
-    resource.queue = resource.queue.filter((q) => !dropQueue.includes(q));
-    reaped += expiredLeases.length + orphanedLeases.length + dropQueue.length;
-    await persistResource(state, resource);
+    const removed = expiredLeases.length + orphanedLeases.length + dropQueue.length;
+    if (removed > 0) {
+      resource.holders = resource.holders.filter(
+        (h) => !expiredLeases.includes(h) && !orphanedLeases.includes(h)
+      );
+      resource.queue = resource.queue.filter((q) => !dropQueue.includes(q));
+      await persistResource(state, resource);
+      reaped += removed;
+    }
 
     for (const lease of expiredLeases) {
       state.appendActivity('RESOURCE_LEASE_EXPIRED', {
@@ -384,6 +419,7 @@ export async function reapResources(state: StateManager, nowMs: number = Date.no
       });
     }
 
+    // Also repair partial release/grant/unblock writes when nothing expired.
     try {
       await grantNextLeases(state, resource.id);
     } catch (err) {

--- a/packages/moe-daemon/src/tools/chatWait.ts
+++ b/packages/moe-daemon/src/tools/chatWait.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from './index.js';
+import type { ToolCallContext, ToolDefinition } from './index.js';
 import type { StateManager } from '../state/StateManager.js';
 import type { ChatMessage } from '../types/schema.js';
 import { invalidInput, missingRequired } from '../util/errors.js';
@@ -60,6 +60,7 @@ interface ChatWaitContext {
   sinceId?: string;
   timeoutMs: number;
   maxContentChars: number;
+  onWaiterRegistered?: ToolCallContext['onWaiterRegistered'];
 }
 
 /**
@@ -97,6 +98,7 @@ class ChatWaitSession {
       timer: this.timer,
       channels: this.ctx.channelSet
     });
+    this.ctx.onWaiterRegistered?.(this.ctx.workerId);
     void this.drainOnEntry();
   }
 
@@ -321,7 +323,7 @@ export function chatWaitTool(_state: StateManager): ToolDefinition {
       required: ['workerId'],
       additionalProperties: false
     },
-    handler: async (args, state) => {
+    handler: async (args, state, context) => {
       const params = (args || {}) as ChatWaitParams;
       validateChatWaitParams(params, state);
 
@@ -362,7 +364,8 @@ export function chatWaitTool(_state: StateManager): ToolDefinition {
           channelSet: params.channels ? new Set(params.channels) : null,
           sinceId: params.sinceId,
           timeoutMs,
-          maxContentChars
+          maxContentChars,
+          onWaiterRegistered: context?.onWaiterRegistered,
         }, resolve).start();
       });
     }

--- a/packages/moe-daemon/src/tools/index.ts
+++ b/packages/moe-daemon/src/tools/index.ts
@@ -65,7 +65,14 @@ import { recordCommitTool } from './recordCommit.js';
 import { declareFilesTool } from './declareFiles.js';
 import { setTaskDependenciesTool } from './setTaskDependencies.js';
 
-export type ToolHandler = (args: unknown, state: StateManager) => Promise<unknown>;
+export interface ToolCallContext {
+  /** Connection lifetime check for asynchronous setup before a long poll parks. */
+  shouldContinue?: () => boolean;
+  /** Called synchronously after a long poll publishes its active waiter. */
+  onWaiterRegistered?: (workerId: string) => void;
+}
+
+export type ToolHandler = (args: unknown, state: StateManager, context?: ToolCallContext) => Promise<unknown>;
 
 export interface ToolDefinition {
   name: string;

--- a/packages/moe-daemon/src/tools/reportBlocked.test.ts
+++ b/packages/moe-daemon/src/tools/reportBlocked.test.ts
@@ -258,6 +258,8 @@ describe('moe.report_blocked', () => {
   });
 
   it('resourceId: queues behind a holder, parks the task, and auto-unblocks on grant', async () => {
+    // A real claim records both ownership pointers before parking the worker.
+    await state.updateWorker('worker-1', { currentTaskId: 'task-1', status: 'CODING' });
     // Another task holds the box.
     const now = new Date().toISOString();
     const holderTask = {
@@ -857,6 +859,8 @@ describe('moe.report_blocked', () => {
         status: 'WORKING', assignedWorkerId: 'worker-1', blockedReason: null,
         blockedResourceId: null, blockedFromStatus: null, blockedAt: null,
       });
+      // Model the peer reclaim fully, including the worker side of ownership.
+      await state.updateWorker('worker-1', { currentTaskId: 'task-1', status: 'CODING' });
       return queued;
     });
 

--- a/packages/moe-daemon/src/tools/waitForResource.ts
+++ b/packages/moe-daemon/src/tools/waitForResource.ts
@@ -53,7 +53,7 @@ export function waitForResourceTool(_state: StateManager): ToolDefinition {
       required: ['resourceId', 'taskId', 'workerId'],
       additionalProperties: false
     },
-    handler: async (args, state) => {
+    handler: async (args, state, context) => {
       const params = (args || {}) as { resourceId?: string; taskId?: string; workerId?: string; timeoutMs?: number };
       const { resourceId, taskId, workerId } = params;
       if (!resourceId) throw missingRequired('resourceId');
@@ -66,6 +66,7 @@ export function waitForResourceTool(_state: StateManager): ToolDefinition {
       if (!task) throw notFound('Task', taskId);
       assertWorkerOwns(task, workerId, 'moe.wait_for_resource');
       await state.touchWorker(workerId);
+      if (context?.shouldContinue?.() === false) return { granted: false, cancelled: true };
 
       // Cancel any existing waiter for this worker (re-entry replaces).
       const existing = activeResourceWaiters.get(workerId);
@@ -78,9 +79,14 @@ export function waitForResourceTool(_state: StateManager): ToolDefinition {
 
       // Blocking tools are dispatched WITHOUT the state mutex — take it for the
       // mutation (grant-or-enqueue), then subscribe lock-free for the park.
-      const immediate = await state.runExclusive(() => state.acquireResource({
-        resourceId, taskId, workerId,
-      }));
+      const immediate = await state.runExclusive(async () => {
+        // A disconnected caller must not take a lease after waiting for the lock.
+        if (context?.shouldContinue?.() === false) return null;
+        return state.acquireResource({ resourceId, taskId, workerId });
+      });
+      // Persistence can also outlive the socket. Keep task-keyed queue/lease
+      // state already written, but never park an RPC cleanup can no longer see.
+      if (!immediate || context?.shouldContinue?.() === false) return { granted: false, cancelled: true };
       if (immediate.granted) {
         return {
           granted: true,
@@ -164,6 +170,7 @@ export function waitForResourceTool(_state: StateManager): ToolDefinition {
           unsubscribe: () => cleanup(),
           timer: timer!,
         });
+        context?.onWaiterRegistered?.(workerId);
       });
     }
   };

--- a/packages/moe-daemon/src/tools/waitForTask.ts
+++ b/packages/moe-daemon/src/tools/waitForTask.ts
@@ -226,7 +226,7 @@ export function waitForTaskTool(_state: StateManager): ToolDefinition {
       required: ['statuses', 'workerId'],
       additionalProperties: false
     },
-    handler: async (args, state) => {
+    handler: async (args, state, context) => {
       const params = (args || {}) as { statuses?: string[]; workerId?: string; epicId?: string; timeoutMs?: number };
       const statuses = params.statuses || [];
       if (statuses.length === 0) {
@@ -240,6 +240,9 @@ export function waitForTaskTool(_state: StateManager): ToolDefinition {
         throw missingRequired('workerId');
       }
       await state.touchWorker(workerId);
+      // Disconnect cleanup may run while the heartbeat write is in flight,
+      // before this call has registered a waiter for it to cancel.
+      if (context?.shouldContinue?.() === false) return { hasNext: false, cancelled: true };
 
       // Cancel any existing waiter for this worker
       const existing = activeWaiters.get(workerId);
@@ -437,6 +440,7 @@ export function waitForTaskTool(_state: StateManager): ToolDefinition {
           unsubscribe: () => cleanup(),
           timer: timer!
         });
+        context?.onWaiterRegistered?.(workerId);
       });
     }
   };

--- a/packages/moe-proxy/package.json
+++ b/packages/moe-proxy/package.json
@@ -54,8 +54,10 @@
     "prebuild": "npm run clean",
     "build": "tsc",
     "start": "node dist/index.js",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "pretest:coverage": "npm run build",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build"
   },

--- a/packages/moe-proxy/src/index.ts
+++ b/packages/moe-proxy/src/index.ts
@@ -485,7 +485,16 @@ function connect(projectPath: string): void {
     const MAX_BUFFER_SIZE = 2 * 1024 * 1024; // 2MB max buffer
     const MAX_LINE_SIZE = 1024 * 1024; // 1MB per-line limit
     let buffer = '';
-    process.stdin.on('data', (chunk) => {
+    let discardingOversizedLine = false;
+    process.stdin.on('data', (chunk: string) => {
+      if (discardingOversizedLine) {
+        // Overflow rejects the entire frame, including future chunks up to
+        // its newline. Its tail must never become a separate tool request.
+        const newline = chunk.indexOf('\n');
+        if (newline < 0) return;
+        chunk = chunk.slice(newline + 1);
+        discardingOversizedLine = false;
+      }
       buffer += chunk;
 
       let index: number;
@@ -496,10 +505,11 @@ function connect(projectPath: string): void {
 
         // Enforce per-line size limit. Emit an id-aware JSON-RPC error so the
         // client isn't left hanging on a request that will never be answered.
-        if (line.length > MAX_LINE_SIZE) {
+        const lineBytes = Buffer.byteLength(line, 'utf8');
+        if (lineBytes > MAX_LINE_SIZE) {
           const oversizedId = extractRequestId(line);
-          writeErrorWithId(oversizedId, `Request too large (${line.length} bytes, max ${MAX_LINE_SIZE})`);
-          writeLog(`Skipping oversized line (${line.length} bytes, max ${MAX_LINE_SIZE})`);
+          writeErrorWithId(oversizedId, `Request too large (${lineBytes} bytes, max ${MAX_LINE_SIZE})`);
+          writeLog(`Skipping oversized line (${lineBytes} bytes, max ${MAX_LINE_SIZE})`);
           continue;
         }
 
@@ -548,11 +558,13 @@ function connect(projectPath: string): void {
       // lines have been drained above, so `buffer` is a single newline-free
       // partial. Only that partial is discarded — already-complete requests that
       // were queued ahead of it are never destroyed.
-      if (buffer.length > MAX_BUFFER_SIZE) {
+      const bufferBytes = Buffer.byteLength(buffer, 'utf8');
+      if (bufferBytes > MAX_BUFFER_SIZE) {
         const overflowId = extractRequestId(buffer);
         writeErrorWithId(overflowId, `Input buffer overflow: partial line exceeds ${MAX_BUFFER_SIZE} bytes`);
-        writeLog(`Input buffer overflow, discarding ${buffer.length}-byte partial line`);
+        writeLog(`Input buffer overflow, discarding ${bufferBytes}-byte partial line`);
         buffer = '';
+        discardingOversizedLine = true;
       }
     });
 

--- a/packages/moe-proxy/src/input-framing.test.ts
+++ b/packages/moe-proxy/src/input-framing.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { once } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { WebSocketServer } from 'ws';
+
+interface RpcResponse {
+  id: number | null;
+  result?: { ok: boolean };
+  error?: { message: string };
+}
+
+describe('moe-proxy stdin framing', () => {
+  let testDir: string;
+  let server: WebSocketServer;
+  let proxy: ChildProcessWithoutNullStreams;
+  let responses: RpcResponse[];
+  let receivedIds: number[];
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-proxy-framing-'));
+    fs.mkdirSync(path.join(testDir, '.moe'));
+    server = new WebSocketServer({ port: 0 });
+    await once(server, 'listening');
+    fs.writeFileSync(path.join(testDir, '.moe', 'daemon.json'), JSON.stringify({
+      port: (server.address() as { port: number }).port,
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      projectPath: testDir,
+    }));
+    responses = [];
+    receivedIds = [];
+    server.on('connection', ws => ws.on('message', data => {
+      const request = JSON.parse(data.toString()) as { id: number };
+      receivedIds.push(request.id);
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { ok: true } }));
+    }));
+    const connected = once(server, 'connection');
+    proxy = spawn(process.execPath, [path.join(__dirname, '../dist/index.js')], {
+      env: { ...process.env, MOE_PROJECT_PATH: testDir },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    proxy.stdout.setEncoding('utf8');
+    proxy.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      let newline: number;
+      while ((newline = stdout.indexOf('\n')) !== -1) {
+        responses.push(JSON.parse(stdout.slice(0, newline)) as RpcResponse);
+        stdout = stdout.slice(newline + 1);
+      }
+    });
+    proxy.stderr.resume();
+    await connected;
+  });
+
+  afterEach(async () => {
+    if (proxy && proxy.exitCode === null && proxy.signalCode === null) {
+      const exited = once(proxy, 'exit');
+      proxy.kill();
+      await exited;
+    }
+    if (server) {
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+    if (testDir) fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const request = (id: number) => JSON.stringify({ jsonrpc: '2.0', id, method: 'ping' });
+
+  it('discards the rest of an overflowing frame through its newline', async () => {
+    const prefix = '{"jsonrpc":"2.0","id":1,"blob":"';
+    // Exactly one byte over the limit ensures overflow happens in the last
+    // input chunk, leaving the following write as the rejected frame's tail.
+    proxy.stdin.write(prefix + 'x'.repeat(2 * 1024 * 1024 + 1 - prefix.length));
+    await vi.waitFor(() => expect(responses.find(r => r.id === 1)?.error?.message ?? '')
+      .toContain('overflow'), { timeout: 5000 });
+
+    proxy.stdin.write(request(2) + '\n' + request(3) + '\n');
+    await vi.waitFor(() => expect(responses.find(r => r.id === 3)?.result).toEqual({ ok: true }));
+
+    expect(receivedIds).toEqual([3]);
+    expect(responses.map(r => r.id)).toEqual([1, 3]);
+  });
+
+  it('enforces the line limit in UTF-8 bytes for non-ASCII requests', async () => {
+    const oversized = JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'ping', blob: '漢'.repeat(400000) });
+    expect(oversized.length).toBeLessThan(1024 * 1024);
+    expect(Buffer.byteLength(oversized, 'utf8')).toBeGreaterThan(1024 * 1024);
+    proxy.stdin.write(oversized + '\n' + request(5) + '\n');
+    await vi.waitFor(() => expect(responses.find(r => r.id === 5)?.result).toEqual({ ok: true }));
+
+    expect(responses.find(r => r.id === 4)?.error?.message ?? '').toContain('too large');
+    expect(receivedIds).toEqual([5]);
+  });
+
+  it('bounds an unterminated non-ASCII frame in UTF-8 bytes', async () => {
+    const prefix = '{"jsonrpc":"2.0","id":6,"blob":"';
+    const partial = prefix + '漢'.repeat(700000);
+    expect(partial.length).toBeLessThan(2 * 1024 * 1024);
+    expect(Buffer.byteLength(partial, 'utf8')).toBeGreaterThan(2 * 1024 * 1024);
+    proxy.stdin.write(partial);
+
+    await vi.waitFor(() => expect(responses.find(r => r.id === 6)?.error?.message ?? '')
+      .toContain('overflow'), { timeout: 3000 });
+    proxy.stdin.write('\n' + request(7) + '\n');
+    await vi.waitFor(() => expect(responses.find(r => r.id === 7)?.result).toEqual({ ok: true }));
+    expect(receivedIds).toEqual([7]);
+    expect(responses.map(r => r.id)).toEqual([6, 7]);
+  });
+});

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -56,6 +56,25 @@ moe_package_install() {
     hash -r
 }
 
+# curl --retry covers only transport errors and 5xx. nodejs.org can answer 404 for a
+# just-published release while its CDN edges catch up (2026-09-09: v24.21.0 under
+# latest-v24.x failed three main runs in a row), so retry HTTP failures here and try
+# the immutable versioned path before the floating alias.
+moe_download() {
+    local output=$1 attempt url
+    shift
+    for attempt in 1 2 3 4; do
+        for url in "$@"; do
+            if curl --fail --location --retry 3 --connect-timeout 20 --max-time 300 --output "$output" "$url"; then
+                return 0
+            fi
+        done
+        [ "$attempt" -lt 4 ] || break
+        sleep "${MOE_DOWNLOAD_RETRY_DELAY_SEC:-5}"
+    done
+    moe_dependency_error "Download failed after $attempt attempts: $*"
+}
+
 moe_install_node() (
     set -e
     local node_os=$1 node_arch=$2 node_root download_dir line_hash line_file archive='' expected=''
@@ -65,7 +84,7 @@ moe_install_node() (
     trap 'rm -rf "$download_dir"' EXIT
     local base_url='https://nodejs.org/dist/latest-v24.x'
     printf 'Installing Node.js 24 from %s\n' "$base_url"
-    curl --fail --location --retry 3 --connect-timeout 20 --max-time 180 --output "$download_dir/SHASUMS256.txt" "$base_url/SHASUMS256.txt" || exit
+    moe_download "$download_dir/SHASUMS256.txt" "$base_url/SHASUMS256.txt" || exit
     while read -r line_hash line_file; do
         if [[ "$line_file" =~ ^node-v24\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz$ ]]; then
             archive=$line_file
@@ -77,7 +96,9 @@ moe_install_node() (
         moe_dependency_error "Official Node.js checksum manifest has no supported $node_os/$node_arch archive."
         exit 1
     fi
-    curl --fail --location --retry 3 --connect-timeout 20 --max-time 300 --output "$download_dir/$archive" "$base_url/$archive" || exit
+    local version=${archive#node-}
+    version=${version%%-*}
+    moe_download "$download_dir/$archive" "https://nodejs.org/dist/$version/$archive" "$base_url/$archive" || exit
     local actual
     if command -v sha256sum >/dev/null 2>&1; then
         actual=$(sha256sum "$download_dir/$archive") || exit

--- a/scripts/tests/dependencies.test.mjs
+++ b/scripts/tests/dependencies.test.mjs
@@ -73,7 +73,15 @@ case "$tool" in
     done
     if [[ "$output" == *SHASUMS256.txt ]]; then
       printf '%064d  node-v24.99.0-%s-%s.tar.gz\\n' 0 "\${MOE_FIXTURE_NODE_OS:-linux}" "\${MOE_FIXTURE_NODE_ARCH:-x64}" > "$output"
-    else printf 'fixture archive' > "$output"; fi
+    else
+      served=$(cat "$MOE_FIXTURE/archive-404-served" 2>/dev/null || echo 0)
+      if [ "$served" -lt "\${MOE_FIXTURE_ARCHIVE_404_COUNT:-0}" ]; then
+        echo $((served + 1)) > "$MOE_FIXTURE/archive-404-served"
+        echo 'curl: (22) The requested URL returned error: 404' >&2
+        exit 22
+      fi
+      printf 'fixture archive' > "$output"
+    fi
     ;;
   tar)
     [ -f "$MOE_FIXTURE/ready/tar" ] || exit 127
@@ -164,6 +172,26 @@ test('old Node is upgraded and a checksum mismatch prevents extraction', t => {
   const result = run(dir, 'claude', false, { MOE_FIXTURE_NODE_VERSION: 'v18.20.0', MOE_FIXTURE_BAD_HASH: '1' });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /checksum/i);
+  assert.doesNotMatch(log(dir), /tar -xzf/);
+});
+
+test('a transient 404 on the Node archive is retried from the versioned path before giving up', t => {
+  const dir = fixture(t, ['git', 'python3', 'curl', 'tar', 'claude']);
+  passed(run(dir, 'claude', false, { MOE_FIXTURE_ARCHIVE_404_COUNT: '2', MOE_DOWNLOAD_RETRY_DELAY_SEC: '0' }));
+  const calls = log(dir);
+  const versioned = calls.match(/https:\/\/nodejs\.org\/dist\/v24\.99\.0\/node-v24\.99\.0-linux-x64\.tar\.gz/g) ?? [];
+  assert.ok(versioned.length >= 2, `expected a retried versioned download, got:\n${calls}`);
+  assert.match(calls, /https:\/\/nodejs\.org\/dist\/latest-v24\.x\/node-v24\.99\.0-linux-x64\.tar\.gz/);
+  assert.ok(calls.indexOf('sha256sum ') < calls.indexOf('tar -xzf '));
+  assert.equal(fs.existsSync(path.join(dir, 'profile/.local/share/moe/node/current/bin/node')), true);
+});
+
+test('a persistent 404 on the Node archive fails actionably without extracting anything', t => {
+  const dir = fixture(t, ['git', 'python3', 'curl', 'tar', 'claude']);
+  const result = run(dir, 'claude', false, { MOE_FIXTURE_ARCHIVE_404_COUNT: '99', MOE_DOWNLOAD_RETRY_DELAY_SEC: '0' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Download failed after 4 attempts/);
+  assert.doesNotMatch(result.stdout, /BOOTSTRAP_OK/);
   assert.doesNotMatch(log(dir), /tar -xzf/);
 });
 


### PR DESCRIPTION
## Summary
- **CI fix**: the Fresh Linux installation job failed three main pushes in a row with `curl: (22) The requested URL returned error: 404` fetching `node-v24.21.0-linux-x64.tar.gz` from `nodejs.org/dist/latest-v24.x` (a two-day-old release; the same URL answers 200 moments later, and `curl --retry` never retries a 404). `moe_install_node` now downloads via a `moe_download` helper that tries the immutable `dist/v<version>/` path first, falls back to the alias, and retries HTTP failures 4× with a delay before failing actionably. Two fixture tests cover transient and persistent 404s.
- **Audit hardening** (docs/audits/2026-09-07-maturity.md): resource-store persistence/grant recovery/queue eligibility/ownership, MCP waiter cancellation on shutdown + async-setup lifetime checks + ownership transfer, plugin message envelope validation, proxy frame/UTF-8 byte limits, JetBrains connection callback fencing, CI covers the Claude plugin build/tests and VS Code typecheck, VSIX excludes dev artifacts. +54 regression tests.
- **Chore**: `.moe/roles` resynced to current `docs/roles`.

## Test plan
- [x] daemon `npm test` 1151/1151, proxy 62/62, `gradlew test` 0 failures
- [x] `node --test scripts/tests/dependencies.test.mjs` 20/20 (2 new), installers 34/34
- [ ] CI green here, including Fresh Linux installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)