### PR TITLE
fix(daemon): startup purge keeps workers that are still heartbeating

### DIFF
--- a/packages/moe-daemon/src/state/StateManager.test.ts
+++ b/packages/moe-daemon/src/state/StateManager.test.ts
@@ -1467,6 +1467,74 @@ describe('StateManager', () => {
         event.payload.workerId === 'worker-missing'
       )).toBe(true);
     });
+
+    // A daemon restart is not evidence its agents died. The daemon can restart
+    // under a live fleet, and deleting a heartbeating registration is
+    // indistinguishable from a crash to that seat: its next tool call is
+    // refused "Unknown sender" and its in-flight task is unassigned under it.
+    it('purgeAllWorkers KEEPS a registration that is still heartbeating', async () => {
+      setupMoeFolder();
+      createTestEpic();
+      createTestTask({ status: 'WORKING', assignedWorkerId: 'worker-live' });
+      createTestWorker({
+        id: 'worker-live',
+        status: 'CODING',
+        currentTaskId: 'task-test123',
+        lastActivityAt: new Date().toISOString(),
+      });
+      await stateManager.load();
+
+      await stateManager.purgeAllWorkers();
+
+      expect(stateManager.getWorker('worker-live')).not.toBeNull();
+      expect(fs.existsSync(path.join(moePath, 'workers', 'worker-live.json'))).toBe(true);
+      // and its work is not yanked out from under it
+      expect(stateManager.getTask('task-test123')?.assignedWorkerId).toBe('worker-live');
+    });
+
+    it('purgeAllWorkers still deletes a registration past the presence window', async () => {
+      setupMoeFolder();
+      createTestEpic();
+      createTestWorker({
+        id: 'worker-stale',
+        lastActivityAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      });
+      await stateManager.load();
+
+      await stateManager.purgeAllWorkers();
+
+      expect(stateManager.getWorker('worker-stale')).toBeNull();
+      expect(fs.existsSync(path.join(moePath, 'workers', 'worker-stale.json'))).toBe(false);
+    });
+
+    it('purgeAllWorkers keeps a live worker in its team but evicts the purged one', async () => {
+      setupMoeFolder();
+      createTestEpic();
+      createTestWorker({ id: 'worker-live', lastActivityAt: new Date().toISOString() });
+      createTestWorker({
+        id: 'worker-stale',
+        lastActivityAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      });
+      fs.mkdirSync(path.join(moePath, 'teams'), { recursive: true });
+      const team = {
+        id: 'team-test123',
+        projectId: 'proj-test123',
+        name: 't',
+        role: 'worker' as const,
+        memberIds: ['worker-live', 'worker-stale'],
+        maxSize: 10,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(path.join(moePath, 'teams', 'team-test123.json'), JSON.stringify(team, null, 2));
+      await stateManager.load();
+
+      await stateManager.purgeAllWorkers();
+
+      const after = stateManager.getTeam('team-test123');
+      expect(after?.memberIds).toEqual(['worker-live']);
+      expect(after?.formerMemberIds ?? []).toContain('worker-stale');
+    });
   });
 
   describe('updateTask identity hardening', () => {

--- a/packages/moe-daemon/src/state/workerStore.ts
+++ b/packages/moe-daemon/src/state/workerStore.ts
@@ -26,7 +26,7 @@ import path from 'path';
 import type { StateManager } from './StateManager.js';
 import type { ActivityEventType, Task, TaskStatus, Worker } from '../types/schema.js';
 import { logger } from '../util/logger.js';
-import { nextStatusForRelease, isWorkerAlive } from './workerLifecycle.js';
+import { nextStatusForRelease, isWorkerAlive, LIVENESS_TIMEOUT_MS } from './workerLifecycle.js';
 import { withEvictionTombstones } from '../util/teamMembershipHeal.js';
 
 // BLOCKED counts as an active hold: a worker parked on a resource queue still
@@ -306,12 +306,37 @@ export async function purgeAllWorkers(state: StateManager): Promise<void> {
   await state.mutex.runExclusive(async () => {
     const workersDir = path.join(state.moePath, 'workers');
     let deletedCount = 0;
+    let keptCount = 0;
 
-    // Delete all worker files from disk
+    // A DAEMON RESTART IS NOT EVIDENCE THAT ITS AGENTS DIED. The daemon can
+    // restart under a live fleet (upgrade, crash-restart, manual bounce), and a
+    // registration still heartbeating inside the presence window belongs to a
+    // process that is very much running. Deleting one is indistinguishable from
+    // a crash to the seat itself: its next tool call is refused with "Unknown
+    // sender", and its in-flight task is unassigned out from under it.
+    //
+    // So purge on the SAME evidence the rest of the fleet already uses -
+    // isWorkerAlive, which listWorkers and the stale watcher key on - instead of
+    // assuming startup implies a previous run. Fail toward KEEPING a
+    // registration: a wrongly-kept one is reclaimed moments later by the
+    // ordinary stale sweep, while a wrongly-deleted one silently decapitates a
+    // live seat mid-task.
+    const now = Date.now();
+    const liveWorkerIds = new Set<string>();
+    for (const worker of state.workers.values()) {
+      if (isWorkerAlive(worker, now, LIVENESS_TIMEOUT_MS)) liveWorkerIds.add(worker.id);
+    }
+
+    // Delete only registrations with no live process behind them.
     try {
       if (fs.existsSync(workersDir)) {
         const files = fs.readdirSync(workersDir).filter((f) => f.endsWith('.json'));
         for (const file of files) {
+          const workerId = file.slice(0, -'.json'.length);
+          if (liveWorkerIds.has(workerId)) {
+            keptCount++;
+            continue;
+          }
           try {
             const workerFile = path.join(workersDir, file);
             // Suppress the watcher echo so our own delete doesn't re-trigger load().
@@ -327,8 +352,10 @@ export async function purgeAllWorkers(state: StateManager): Promise<void> {
       logger.error({ error }, 'Failed to read workers directory during purge');
     }
 
-    // Clear workers map
-    state.workers.clear();
+    // Drop only the purged records from the map; live ones stay registered.
+    for (const workerId of [...state.workers.keys()]) {
+      if (!liveWorkerIds.has(workerId)) state.workers.delete(workerId);
+    }
 
     // Clear assignedWorkerId references that are now orphaned.
     let clearedAssignments = 0;
@@ -368,10 +395,15 @@ export async function purgeAllWorkers(state: StateManager): Promise<void> {
     // instead of coming back as a solo — see util/teamMembershipHeal.ts.
     for (const team of state.teams.values()) {
       if (team.memberIds.length === 0) continue;
+      // Evict only members whose registration was actually purged. A live
+      // worker that keeps its record must keep its membership too, or it comes
+      // back as a solo and loses its team's role.
+      const evicted = team.memberIds.filter((id) => !liveWorkerIds.has(id));
+      if (evicted.length === 0) continue;
       const updated = {
         ...team,
-        memberIds: [],
-        formerMemberIds: withEvictionTombstones(team, team.memberIds),
+        memberIds: team.memberIds.filter((id) => liveWorkerIds.has(id)),
+        formerMemberIds: withEvictionTombstones(team, evicted),
         updatedAt: new Date().toISOString()
       };
       state.teams.set(team.id, updated);
@@ -384,7 +416,7 @@ export async function purgeAllWorkers(state: StateManager): Promise<void> {
     }
 
     if (deletedCount > 0) {
-      logger.info({ count: deletedCount, clearedAssignments }, 'Purged stale workers from previous run');
+      logger.info({ count: deletedCount, kept: keptCount, clearedAssignments }, 'Purged stale workers from previous run');
     } else if (clearedAssignments > 0) {
       logger.info({ clearedAssignments }, 'Cleared orphan task assignments during worker purge');
     }

--- a/packages/moe-daemon/src/tools/claimNextTask.test.ts
+++ b/packages/moe-daemon/src/tools/claimNextTask.test.ts
@@ -722,6 +722,16 @@ describe('moe.claim_next_task — team-membership refusal and auto-heal', () => 
     const team = await state.createTeam({ name: 'workers', role: 'worker' });
     await state.addTeamMember(team.id, 'w-solo');
 
+    // Age w-solo past the presence window AFTER joining the team (the join
+    // refreshes its heartbeat), so the startup purge actually purges it:
+    // purgeAllWorkers now KEEPS registrations that are still heartbeating, so a
+    // fresh fixture would survive and this scenario would never arise.
+    const solo = state.getWorker('w-solo')!;
+    state.workers.set('w-solo', {
+      ...solo,
+      lastActivityAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    });
+
     await state.purgeAllWorkers();
     expect(state.getWorker('w-solo')).toBeNull();
     expect(state.getTeam(team.id)?.memberIds).toEqual([]);


### PR DESCRIPTION
`purgeAllWorkers` deleted **every** worker registration on daemon start, on the assumption that startup implies the previous run had ended. It does not — the daemon restarts under a live fleet (upgrade, crash-restart, manual bounce), and every registration heartbeating inside the presence window belongs to a process that is still running.

## What it does to a live seat

Deleting one is **indistinguishable from a crash to the seat itself**:

- its next tool call is refused `Unknown sender: workerId must be a registered worker`
- its in-flight task is unassigned out from under it
- its team membership is tombstoned, so it returns as a solo and loses its role

Nothing warns anyone, and the seat looks dead to every liveness signal the fleet has — which is exactly what the stale-worker discipline exists to distinguish. Recovery is a manual `join_team` + `enter_governance`.

**Observed on moe-next, 2026-09-09/10.** `startup-worker-purge` decapitated two governor seats mid-thread at 20:50:37Z, then the same seat twice more, each time mid-task, with no crash anywhere on the host.

## The change

Purge now keys on the **same evidence the rest of the fleet already uses** — `isWorkerAlive`, shared by `listWorkers` and the stale watcher — instead of on the startup assumption.

- registrations past the presence window: deleted exactly as before
- live ones: keep their file, their map entry and their team membership
- teams: only genuinely purged members are evicted and tombstoned
- log line reports `kept` alongside `count`

**It fails toward keeping a registration.** A wrongly-kept one is reclaimed moments later by the ordinary stale sweep; a wrongly-deleted one loses a live seat's work. The asymmetry is the whole point.

## Tests

Three regressions in `StateManager.test.ts`:

| Case | Asserts |
|---|---|
| heartbeating worker | survives the purge, keeps its assignment |
| worker past the window | still deleted, file gone |
| team with one live + one stale member | keeps the live member, evicts and tombstones the purged one |

**Mutation-checked**: disabling the liveness check restores the old behaviour and reds two of the three. Source restored by SHA256 equality against its pre-mutation hash, in a call separate from the restore.

`claimNextTask`'s auto-heal test ages its fixture *after* the team join, because the join refreshes the heartbeat and the purge it depends on would otherwise no longer occur. Its assertion is unchanged — the auto-heal path still matters for genuinely stale workers.

```
packages/moe-daemon:  tsc --noEmit                 EXIT 0
                      src/state + src/tools        67 files / 809 tests  EXIT 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMTJnSYooxgPJxTGVLsySo