### PR TITLE
fix(chat): two independent chat-routing defects — channel-name references, and the loop guard the daemon kept resetting

### DIFF
--- a/packages/moe-daemon/src/state/StateManager.ts
+++ b/packages/moe-daemon/src/state/StateManager.ts
@@ -153,6 +153,7 @@ import {
   postToGeneral,
   postToRoleChannel,
   rejectDecision,
+  resolveChannelRef,
   sendMessage,
   togglePinDone,
   unpinMessage,
@@ -765,6 +766,10 @@ export class StateManager {
 
   getChannels(): ChatChannel[] {
     return getChannels(this);
+  }
+
+  resolveChannelRef(ref: string): ChatChannel | null {
+    return resolveChannelRef(this, ref);
   }
 
   async createChannel(opts: {

--- a/packages/moe-daemon/src/state/chatStore.ts
+++ b/packages/moe-daemon/src/state/chatStore.ts
@@ -84,6 +84,33 @@ export function getChannel(state: StateManager, channelId: string): ChatChannel 
   return state.channels.get(channelId) || null;
 }
 
+/**
+ * Resolve a caller-supplied channel REFERENCE to its channel.
+ *
+ * Accepts the canonical id ("chan-<uuid>"), the bare name ("governors"), or the
+ * display form the role docs and the seat pre-flight prompts actually use
+ * ("#governors"). Every chat tool that takes a channel from a caller goes
+ * through this, so the form a governor is TOLD to pass is the form that works.
+ *
+ * The exact id always wins. A name resolves only when it identifies exactly one
+ * channel: two channels sharing a name make the reference ambiguous, and
+ * silently picking one would point a long-poll at the wrong log, so the
+ * reference resolves to null and the caller refuses as it did before.
+ */
+export function resolveChannelRef(state: StateManager, ref: string): ChatChannel | null {
+  const exact = state.channels.get(ref);
+  if (exact) return exact;
+  const name = ref.startsWith('#') ? ref.slice(1) : ref;
+  if (!name) return null;
+  let match: ChatChannel | null = null;
+  for (const channel of state.channels.values()) {
+    if (channel.name !== name) continue;
+    if (match) return null;
+    match = channel;
+  }
+  return match;
+}
+
 export function getChannels(state: StateManager): ChatChannel[] {
   return Array.from(state.channels.values()).sort(
     (a, b) => a.createdAt.localeCompare(b.createdAt)

--- a/packages/moe-daemon/src/tools/chatChannelRef.test.ts
+++ b/packages/moe-daemon/src/tools/chatChannelRef.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Channel REFERENCES on the chat tools.
+ *
+ * The governance pre-flight prompt that scripts/moe-agent.ps1 and
+ * scripts/moe-agent.sh inject into every governor seat says, verbatim:
+ *
+ *   "moe.chat_read #general ... enter the loop: moe.chat_wait with
+ *    channels=['#governors','#general'] and a long timeout"
+ *
+ * Before this fix the daemon refused that exact call with
+ *   [INVALID_INPUT] Invalid channels: unknown channel: #governors
+ * and moe.chat_read '#general' returned an empty page, which reads as a quiet
+ * channel rather than as an unresolved reference. These arms hold the tools to
+ * the reference form their own instructions hand out.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { StateManager } from '../state/StateManager.js';
+import { chatWaitTool } from './chatWait.js';
+import { chatReadTool } from './chatRead.js';
+import { chatSendTool } from './chatSend.js';
+import type { ChatMessage, Worker } from '../types/schema.js';
+
+const WORKER_ID = 'governor-ref';
+const TIMEOUT_MS = 1000;
+
+interface WaitResult {
+  hasMessage: boolean;
+  messages?: Array<{ id: string; channel: string; content: string }>;
+  timedOut?: boolean;
+}
+
+interface ReadResult {
+  messages: Array<{ id: string; channel: string; content: string }>;
+}
+
+describe('chat tools accept a channel name as well as an id', () => {
+  let testDir: string;
+  let state: StateManager;
+  let channels: Record<string, string>;
+
+  const wait = (args: Record<string, unknown>): Promise<WaitResult> =>
+    chatWaitTool(state).handler({ workerId: WORKER_ID, timeoutMs: TIMEOUT_MS, ...args }, state) as Promise<WaitResult>;
+  const read = (args: Record<string, unknown>): Promise<ReadResult> =>
+    chatReadTool(state).handler(args, state) as Promise<ReadResult>;
+  const send = (args: Record<string, unknown>): Promise<unknown> =>
+    chatSendTool(state).handler(args, state);
+
+  const post = async (channel: string, content: string, sender = 'human'): Promise<ChatMessage> => {
+    const { message } = await state.sendMessage({ channel, sender, content });
+    return message;
+  };
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moe-chatref-test-'));
+    const moePath = path.join(testDir, '.moe');
+    for (const dir of ['epics', 'tasks', 'workers', 'proposals', 'teams', 'channels', 'messages']) {
+      fs.mkdirSync(path.join(moePath, dir), { recursive: true });
+    }
+    fs.writeFileSync(path.join(moePath, 'project.json'), JSON.stringify({
+      id: 'proj-test',
+      name: 'Chat Ref Project',
+      rootPath: testDir,
+      globalRails: { techStack: [], forbiddenPatterns: [], requiredPatterns: [], formatting: '', testing: '', customRules: [] },
+      settings: { approvalMode: 'CONTROL', agentCommand: 'claude' },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }, null, 2));
+
+    const worker: Worker = {
+      id: WORKER_ID,
+      type: 'CLAUDE',
+      projectId: 'proj-test',
+      epicId: null,
+      currentTaskId: null,
+      status: 'IDLE',
+      branch: 'main',
+      modifiedFiles: [],
+      startedAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+      lastError: null,
+      errorCount: 0,
+    };
+    fs.writeFileSync(path.join(moePath, 'workers', `${WORKER_ID}.json`), JSON.stringify(worker, null, 2));
+
+    state = new StateManager({ projectPath: testDir });
+    await state.load();
+    channels = {};
+    for (const channel of state.getChannels()) channels[channel.name] = channel.id;
+    expect(channels.governors).toBeDefined();
+    expect(channels.general).toBeDefined();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('moe.chat_wait', () => {
+    it('accepts the exact filter the governance pre-flight prompt injects', async () => {
+      const message = await post(channels.governors, 'stale-worker alert', 'system');
+
+      // The pre-empted red was thrown by validation, before any delivery.
+      const result = await wait({ channels: ['#governors', '#general'] });
+
+      expect(result.messages?.map((m) => m.id)).toEqual([message.id]);
+      expect(result.hasMessage).toBe(true);
+    });
+
+    it('delivers on a bare name too, and reports the canonical id back', async () => {
+      const message = await post(channels.governors, 'qa rejection', 'system');
+
+      const result = await wait({ channels: ['governors'] });
+
+      expect(result.messages?.map((m) => m.channel)).toEqual([channels.governors]);
+      expect(result.messages?.map((m) => m.id)).toEqual([message.id]);
+    });
+
+    it('does not merely validate the name: an unwatched channel is still filtered out', async () => {
+      // Guards the half of the defect a validation-only fix would leave behind —
+      // a resolved-looking filter that matches no message.channel and blocks to
+      // timeout on a channel that exists and has traffic.
+      await post(channels.general, 'not in the governors channel', 'system');
+
+      const result = await wait({ channels: ['#governors'] });
+
+      expect(result.hasMessage).toBe(false);
+      expect(result.timedOut).toBe(true);
+    });
+
+    it('still refuses a channel that does not exist', async () => {
+      await expect(wait({ channels: ['#nope'] })).rejects.toThrow('unknown channel: #nope');
+    });
+
+    it('refuses an ambiguous name rather than picking one of two channels', async () => {
+      // createChannel only rejects a duplicate name within one TYPE, so a custom
+      // channel someone names "governors" sits alongside the role channel of the
+      // same name — and every governor's '#governors' long-poll becomes ambiguous.
+      const twin = await state.createChannel({ name: 'governors', type: 'custom' });
+      expect(twin.id).not.toBe(channels.governors);
+
+      await expect(wait({ channels: ['#governors'] })).rejects.toThrow('unknown channel: #governors');
+      // The ids themselves stay addressable; only the shared NAME is ambiguous.
+      await expect(wait({ channels: [channels.governors] })).resolves.toMatchObject({ hasMessage: false });
+    });
+  });
+
+  describe('moe.chat_read', () => {
+    it('reads a named channel instead of returning an empty page', async () => {
+      const message = await post(channels.general, 'governor online', 'system');
+
+      const result = await read({ channel: '#general', workerId: WORKER_ID, limit: 10 });
+
+      expect(result.messages.map((m) => m.id)).toEqual([message.id]);
+    });
+
+    it('keys the saved cursor on the canonical id, not on the reference', async () => {
+      const message = await post(channels.general, 'first', 'system');
+      await read({ channel: '#general', workerId: WORKER_ID, limit: 10 });
+
+      const cursors = state.getWorker(WORKER_ID)?.chatCursors ?? {};
+      expect(cursors[channels.general]).toBe(message.id);
+      expect(cursors['#general']).toBeUndefined();
+
+      // A cursor under the reference would re-serve the same message forever;
+      // the second read, by ID this time, must see the cursor the first one set.
+      const second = await read({ channel: channels.general, workerId: WORKER_ID, limit: 10 });
+      expect(second.messages).toEqual([]);
+    });
+
+    it('refuses an unresolvable channel instead of reporting it quiet', async () => {
+      await expect(read({ channel: '#nope', workerId: WORKER_ID })).rejects.toThrow('Channel');
+    });
+  });
+
+  describe('moe.chat_send', () => {
+    it('stores the message under the canonical channel id', async () => {
+      await send({ channel: '#general', content: 'sent by name', workerId: WORKER_ID });
+
+      const stored = await state.getMessages(channels.general, { limit: 10 });
+      expect(stored.map((m) => m.content)).toContain('sent by name');
+      // A message stored under "#general" belongs to no channel any reader can
+      // fetch, so the send would look successful and be invisible.
+      expect(stored.every((m) => m.channel === channels.general)).toBe(true);
+    });
+
+    it('threads a reply by name against the resolved channel', async () => {
+      const parent = await post(channels.general, 'parent', 'system');
+
+      await send({ channel: '#general', content: 'child', workerId: WORKER_ID, replyTo: parent.id });
+
+      const stored = await state.getMessages(channels.general, { limit: 10 });
+      expect(stored.find((m) => m.content === 'child')?.replyTo).toBe(parent.id);
+    });
+  });
+});

--- a/packages/moe-daemon/src/tools/chatRead.ts
+++ b/packages/moe-daemon/src/tools/chatRead.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from './index.js';
 import type { StateManager } from '../state/StateManager.js';
 import type { ChatMessage } from '../types/schema.js';
-import { invalidInput } from '../util/errors.js';
+import { invalidInput, notFound } from '../util/errors.js';
 import {
   countTruncatedMessages,
   DEFAULT_CHAT_CONTENT_CHARS,
@@ -19,7 +19,7 @@ export function chatReadTool(_state: StateManager): ToolDefinition {
     inputSchema: {
       type: 'object',
       properties: {
-        channel: { type: 'string', description: 'Channel ID (omit to read from all channels)' },
+        channel: { type: 'string', description: 'Channel id, or name in either "general" or "#general" form (omit to read from all channels)' },
         workerId: { type: 'string', description: 'Worker ID for auto-cursor tracking' },
         sinceId: { type: 'string', description: 'Return messages after this message ID' },
         limit: { type: 'number', description: 'Max messages to return (default 10, max 200)' },
@@ -56,21 +56,35 @@ export function chatReadTool(_state: StateManager): ToolDefinition {
         ? Math.min(Math.floor(params.maxContentChars), MAX_CHAT_CONTENT_CHARS)
         : DEFAULT_CHAT_CONTENT_CHARS;
 
+      // Callers name a channel the way the role docs and the seat pre-flight
+      // prompts do ("#general") at least as often as by id. Resolve the
+      // reference ONCE, up front, so the saved cursor, the fetch and the unread
+      // clear all key on the same canonical id. A reference that resolves to
+      // nothing is refused here: reading an absent channel used to return an
+      // empty page, which reads as "this channel is quiet" and is how a seat
+      // comes to make a confident false claim about a channel.
+      let channelId: string | undefined;
+      if (params.channel !== undefined) {
+        const channel = state.resolveChannelRef(params.channel);
+        if (!channel) throw notFound('Channel', params.channel);
+        channelId = channel.id;
+      }
+
       let messages: ChatMessage[];
       let sinceId = params.sinceId;
       let allChannelFetchedMessages: ChatMessage[] = [];
 
       // If workerId provided and no explicit sinceId, use worker's saved cursor
-      if (params.workerId && !sinceId && params.channel) {
+      if (params.workerId && !sinceId && channelId) {
         const worker = state.getWorker(params.workerId);
         if (worker?.chatCursors) {
-          sinceId = worker.chatCursors[params.channel];
+          sinceId = worker.chatCursors[channelId];
         }
       }
 
-      if (params.channel) {
+      if (channelId) {
         // Read from a specific channel
-        messages = await state.getMessages(params.channel, { sinceId, limit });
+        messages = await state.getMessages(channelId, { sinceId, limit });
       } else {
         // Read from all channels, merge and sort by timestamp
         const channels = state.getChannels();
@@ -125,8 +139,8 @@ export function chatReadTool(_state: StateManager): ToolDefinition {
       // Update worker's chat cursor atomically if workerId provided
       if (params.workerId && messages.length > 0) {
         const cursorUpdates: Record<string, string> = {};
-        if (params.channel) {
-          cursorUpdates[params.channel] = cursor!;
+        if (channelId) {
+          cursorUpdates[channelId] = cursor!;
         } else {
           for (const msg of messages) {
             if (!allChannelChannelsWithOmittedFetchedMessages.has(msg.channel)) {
@@ -141,8 +155,8 @@ export function chatReadTool(_state: StateManager): ToolDefinition {
 
       // Clear unread notification counts only when messages were actually read
       if (params.workerId && messages.length > 0) {
-        if (params.channel) {
-          state.clearUnread(params.workerId, params.channel);
+        if (channelId) {
+          state.clearUnread(params.workerId, channelId);
         } else {
           for (const channelId of new Set(messages.map((msg) => msg.channel))) {
             if (!allChannelChannelsWithOmittedFetchedMessages.has(channelId)) {

--- a/packages/moe-daemon/src/tools/chatSend.ts
+++ b/packages/moe-daemon/src/tools/chatSend.ts
@@ -9,7 +9,7 @@ export function chatSendTool(_state: StateManager): ToolDefinition {
     inputSchema: {
       type: 'object',
       properties: {
-        channel: { type: 'string', description: 'Channel ID to send to' },
+        channel: { type: 'string', description: 'Channel id, or name in either "general" or "#general" form' },
         content: { type: 'string', description: 'Message text (max 10KB)' },
         workerId: { type: 'string', description: 'Sender worker ID (defaults to "human")' },
         replyTo: { type: 'string', description: 'Message ID to reply to (threading)' }
@@ -52,7 +52,7 @@ export function chatSendTool(_state: StateManager): ToolDefinition {
         }
       }
 
-      const channel = state.getChannel(params.channel);
+      const channel = state.resolveChannelRef(params.channel);
       if (!channel) throw notFound('Channel', params.channel);
 
       // Validate replyTo points to a real message in the same channel.
@@ -60,13 +60,15 @@ export function chatSendTool(_state: StateManager): ToolDefinition {
         if (typeof params.replyTo !== 'string') {
           throw invalidInput('replyTo', 'must be a string');
         }
-        if (!state.messageExistsInChannel(params.channel, params.replyTo)) {
+        if (!state.messageExistsInChannel(channel.id, params.replyTo)) {
           throw invalidInput('replyTo', `message ${params.replyTo} not found in channel ${params.channel}`);
         }
       }
 
+      // channel.id, never the caller's reference: a message stored under
+      // "#general" would belong to no channel any reader can fetch.
       const { message, routingTargets } = await state.sendMessage({
-        channel: params.channel,
+        channel: channel.id,
         sender,
         content: params.content,
         replyTo: params.replyTo

--- a/packages/moe-daemon/src/tools/chatWait.ts
+++ b/packages/moe-daemon/src/tools/chatWait.ts
@@ -290,17 +290,32 @@ function validateChatWaitParams(params: ChatWaitParams, state: StateManager): vo
   }
   if (params.channels !== undefined) {
     if (!Array.isArray(params.channels)) {
-      throw invalidInput('channels', 'must be an array of channel IDs');
+      throw invalidInput('channels', 'must be an array of channel references');
     }
     for (const ch of params.channels) {
       if (typeof ch !== 'string' || !ch) {
-        throw invalidInput('channels', 'each channel ID must be a non-empty string');
+        throw invalidInput('channels', 'each channel reference must be a non-empty string');
       }
-      if (!state.getChannel(ch)) {
+      if (!state.resolveChannelRef(ch)) {
         throw invalidInput('channels', `unknown channel: ${ch}`);
       }
     }
   }
+}
+
+/**
+ * Canonical channel ids for a caller's filter. The subscription set is matched
+ * against `message.channel`, which only ever holds an id — so a reference that
+ * merely VALIDATED would filter every message out and the caller would block to
+ * timeout on a channel that exists. Resolve, never pass the raw reference on.
+ */
+function resolveChannelFilter(state: StateManager, channels: string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const ref of channels) {
+    const channel = state.resolveChannelRef(ref);
+    if (channel) ids.add(channel.id);
+  }
+  return ids;
 }
 
 export function chatWaitTool(_state: StateManager): ToolDefinition {
@@ -312,7 +327,7 @@ export function chatWaitTool(_state: StateManager): ToolDefinition {
       type: 'object',
       properties: {
         workerId: { type: 'string', description: 'Your worker ID (messages mentioning you will trigger)' },
-        channels: { type: 'array', items: { type: 'string' }, description: 'Optional channel filter' },
+        channels: { type: 'array', items: { type: 'string' }, description: 'Optional channel filter: channel ids, or names in either "governors" or "#governors" form' },
         sinceId: { type: 'string', description: 'Explicit catch-up cursor: overrides the stored per-channel cursor' },
         timeoutMs: { type: 'number', description: 'Max wait time in ms (default 300000, max 600000)' },
         maxContentChars: {
@@ -361,7 +376,7 @@ export function chatWaitTool(_state: StateManager): ToolDefinition {
         new ChatWaitSession({
           state,
           workerId,
-          channelSet: params.channels ? new Set(params.channels) : null,
+          channelSet: params.channels ? resolveChannelFilter(state, params.channels) : null,
           sinceId: params.sinceId,
           timeoutMs,
           maxContentChars,

--- a/packages/moe-daemon/src/util/mentionRouter.ts
+++ b/packages/moe-daemon/src/util/mentionRouter.ts
@@ -190,8 +190,19 @@ export class MentionRouter {
    */
   route(message: ChatMessage, allWorkers: Worker[], teams?: Team[]): RoutingResult {
     const knownWorkerIds = allWorkers.map((w) => w.id);
-    const isHuman = message.sender === 'human' || message.sender === 'system' ||
-      !knownWorkerIds.includes(message.sender);
+
+    // The daemon's own bookkeeping is NEITHER a human resuming the channel nor
+    // an agent taking a hop, so it routes neutrally. It used to take the human
+    // path, which resets hopCounts to 0 and clears the pause — and on a working
+    // channel a checkpoint banner, a "Step N completed", a claim notice or a
+    // resource grant lands every minute or so, so the loop guard was being
+    // reset faster than agents could reach maxHops and could effectively never
+    // fire on exactly the busy channel it exists to protect.
+    if (message.sender === 'system') {
+      return this.routeSystemMessage(message, allWorkers, knownWorkerIds, teams);
+    }
+
+    const isHuman = message.sender === 'human' || !knownWorkerIds.includes(message.sender);
 
     if (isHuman) {
       return this.routeHumanMessage(message, allWorkers, knownWorkerIds, teams);
@@ -229,6 +240,37 @@ export class MentionRouter {
     }
 
     return { targets: mentions, paused: false, hopCount: 0 };
+  }
+
+  /**
+   * System messages: delivered, but with no effect on the loop guard.
+   *
+   * Targets are chosen exactly as before — explicit mentions if the banner has
+   * any, otherwise every non-IDLE, non-DEAD worker — so a stale-worker alert
+   * still reaches its seats even while the channel is paused. A pause exists to
+   * stop agents answering each other, not to hide the daemon's own warnings.
+   * What it must NOT do is touch hopCounts or pausedChannels: only a human, or
+   * an explicit @continue, resumes a channel.
+   */
+  private routeSystemMessage(
+    message: ChatMessage,
+    allWorkers: Worker[],
+    knownWorkerIds: string[],
+    teams?: Team[]
+  ): RoutingResult {
+    const channel = message.channel;
+    const mentions = this.parseMentions(message.content, knownWorkerIds, allWorkers, teams);
+    const targets = mentions.length > 0
+      ? mentions
+      : allWorkers
+          .filter((w) => w.status !== 'IDLE' && w.status !== 'DEAD')
+          .map((w) => w.id);
+
+    return {
+      targets,
+      paused: this.pausedChannels.has(channel),
+      hopCount: this.hopCounts.get(channel) ?? 0,
+    };
   }
 
   private routeAgentMessage(

--- a/packages/moe-daemon/src/util/mentionRouterSystemHops.test.ts
+++ b/packages/moe-daemon/src/util/mentionRouterSystemHops.test.ts
@@ -1,0 +1,147 @@
+/**
+ * System messages must be NEUTRAL for the loop guard.
+ *
+ * Observed 2026-09-10 in #workers: two seats exchanged seven messages over
+ * eighteen minutes, each correctly reporting who held a resource lease, each
+ * @-tagging the other, each answering a snapshot that had already expired. With
+ * maxHops = 4 the guard should have paused the channel after four. It never
+ * fired, because `route()` classified `sender === 'system'` as a human message,
+ * and the human path unconditionally resets hopCounts to 0 and clears the
+ * pause. On a working channel the daemon's own bookkeeping — checkpoint commit
+ * banners, "Step N completed", claim notices, resource grants — arrives about
+ * once a minute, which reset the counter faster than the agents could reach the
+ * limit. A governor's containment message did not stop the loop either; only
+ * the seats running out of things to say did.
+ */
+import { describe, it, expect } from 'vitest';
+import { MentionRouter } from './mentionRouter.js';
+import type { ChatMessage, Worker } from '../types/schema.js';
+
+const makeWorker = (id: string, overrides: Partial<Worker> = {}): Worker => ({
+  id,
+  type: 'CLAUDE',
+  projectId: 'proj-test',
+  epicId: 'epic-test',
+  currentTaskId: null,
+  status: 'CODING',
+  branch: '',
+  modifiedFiles: [],
+  startedAt: new Date().toISOString(),
+  lastActivityAt: new Date().toISOString(),
+  lastError: null,
+  errorCount: 0,
+  teamId: null,
+  ...overrides,
+});
+
+const makeMessage = (sender: string, content: string): ChatMessage => ({
+  id: 'msg-test',
+  channel: 'chan-workers',
+  sender,
+  content,
+  replyTo: null,
+  mentions: [],
+  timestamp: new Date().toISOString(),
+});
+
+const WORKERS = [
+  makeWorker('worker-alice'),
+  makeWorker('worker-bob'),
+  makeWorker('worker-idle', { status: 'IDLE' }),
+];
+
+/** The shape of the banners the daemon posts while a channel is working. */
+const CHECKPOINT = makeMessage(
+  'system',
+  '📦 checkpoint commit recorded for task-abc: 725613088aae — 2 path(s), 0 inferred, pushed'
+);
+const PING = makeMessage('worker-alice', '@worker-bob who holds the gate');
+
+describe('a system message does not resume a channel', () => {
+  it('does not reset the hop counter between agent hops', () => {
+    const router = new MentionRouter(4);
+
+    // One banner between each agent hop — the real interleaving in #workers.
+    for (let hop = 1; hop <= 4; hop += 1) {
+      const agent = router.route(PING, WORKERS);
+      expect(agent.hopCount).toBe(hop);
+      expect(agent.paused).toBe(false);
+      router.route(CHECKPOINT, WORKERS);
+    }
+
+    // Fifth routable hop exceeds maxHops even though four banners intervened.
+    // Before the fix this returned hopCount 1 forever and never paused.
+    const fifth = router.route(PING, WORKERS);
+    expect(fifth.hopCount).toBe(5);
+    expect(fifth.paused).toBe(true);
+    expect(fifth.targets).toEqual([]);
+  });
+
+  it('does not clear an existing pause', () => {
+    const router = new MentionRouter(4);
+    for (let i = 0; i <= 4; i += 1) router.route(PING, WORKERS);
+    expect(router.getChannelState('chan-workers').paused).toBe(true);
+
+    router.route(CHECKPOINT, WORKERS);
+
+    expect(router.getChannelState('chan-workers').paused).toBe(true);
+    expect(router.route(PING, WORKERS).targets).toEqual([]);
+  });
+
+  it('reports the channel state it found rather than a fresh one', () => {
+    const router = new MentionRouter(4);
+    for (let i = 0; i <= 4; i += 1) router.route(PING, WORKERS);
+
+    const banner = router.route(CHECKPOINT, WORKERS);
+
+    expect(banner.paused).toBe(true);
+    expect(banner.hopCount).toBe(5);
+  });
+
+  it('still delivers the banner on a paused channel', () => {
+    // The pause stops agents answering each other. It must not hide a
+    // stale-worker alert from the seat that needs to act on it.
+    const router = new MentionRouter(4);
+    for (let i = 0; i <= 4; i += 1) router.route(PING, WORKERS);
+
+    const broadcast = router.route(CHECKPOINT, WORKERS);
+    expect(broadcast.targets).toEqual(['worker-alice', 'worker-bob']);
+
+    // Real banners name a worker WITHOUT an "@" ("⚠️ worker-bob stale on ..."),
+    // so they parse to no mentions and broadcast. That is pre-existing routing
+    // and this change does not touch it; the arm pins it so the neutral path
+    // cannot quietly start swallowing alerts on a paused channel.
+    const alert = router.route(
+      makeMessage('system', '⚠️ worker-bob stale on task-abc — last activity 281s ago'),
+      WORKERS
+    );
+    expect(alert.targets).toEqual(['worker-alice', 'worker-bob']);
+    expect(alert.paused).toBe(true);
+  });
+
+  it('honours an explicit @mention in a banner when one is present', () => {
+    const router = new MentionRouter(4);
+
+    const addressed = router.route(makeMessage('system', 'grant went to @worker-bob'), WORKERS);
+
+    expect(addressed.targets).toEqual(['worker-bob']);
+    expect(addressed.hopCount).toBe(0);
+  });
+
+  it('leaves an IDLE worker out of an unaddressed banner, as before', () => {
+    const router = new MentionRouter(4);
+    expect(router.route(CHECKPOINT, WORKERS).targets).not.toContain('worker-idle');
+  });
+
+  it('still lets a human resume the channel', () => {
+    // The escape hatch has to keep working, or a paused channel is a dead one.
+    const router = new MentionRouter(4);
+    for (let i = 0; i <= 4; i += 1) router.route(PING, WORKERS);
+    expect(router.getChannelState('chan-workers').paused).toBe(true);
+
+    router.route(makeMessage('human', 'carry on'), WORKERS);
+
+    expect(router.getChannelState('chan-workers').paused).toBe(false);
+    expect(router.route(PING, WORKERS)).toMatchObject({ paused: false, hopCount: 1 });
+  });
+});


### PR DESCRIPTION
Two independent defects in chat routing, one commit each, both found live by a governor seat this session. Kept in one PR because the merge is blocked on a human and one command is kinder than two; nothing else is bundled in.

---

## 1. `5dcda4c` — the chat tools refused the channel form their own prompt hands out

Both launcher twins inject this into every governor seat (`scripts/moe-agent.ps1:4308`, `scripts/moe-agent.sh:5067`):

> "moe.chat_read #general ... enter the loop: moe.chat_wait with channels=['#governors','#general'] and a long timeout"

The daemon refused that exact call:

```
[INVALID_INPUT] Invalid channels: unknown channel: #governors
```

`chat_read '#general'` was the worse half: no channel validation at all, so it returned an empty page and wrote a cursor under the bogus key. That reads as "the channel is quiet" rather than "your reference resolved to nothing" — the shape of a confident false negative about a channel.

`resolveChannelRef()` in `chatStore`: exact id wins, then a name in `governors` or `#governors` form, and only when it identifies exactly one channel. `createChannel` rejects a duplicate name within one type but not across types, so a custom channel named `governors` can sit beside the role channel; that reference stays ambiguous and is refused rather than pointing a long-poll at the wrong log.

Wired into the three tools that take a channel from a caller, resolving to the canonical id rather than merely validating:

- **chat_wait** — the subscription set is matched against `message.channel`, which only holds ids. A validation-only fix would accept `#governors`, filter every message out, and block to timeout on a channel that exists and has traffic.
- **chat_send** — stores `channel.id`. A message stored under `"#general"` belongs to no channel any reader can fetch: a successful-looking invisible send.
- **chat_read** — resolves once so cursor, fetch and unread-clear key on the same id; an unresolvable reference is now refused instead of reported quiet. This is the one behaviour change beyond a widening, and there are no programmatic callers — every `chat_read` reference in the tree is prompt or hint text.

## 2. `9623adc` — a system message reset the agent loop guard

Observed in `#workers`: two seats exchanged **seven** messages over eighteen minutes, each correctly reporting who held a resource lease, each @-tagging the other, each answering a snapshot that had already expired because the lease legitimately moved twice mid-exchange. With `maxHops = 4` the guard should have paused the channel after four. It never fired, and an explicit governor instruction to stop did not either.

One clause in `route()`:

```ts
const isHuman = message.sender === 'human' || message.sender === 'system' ||
  !knownWorkerIds.includes(message.sender);
```

`system` took the human path, and `routeHumanMessage` unconditionally does `hopCounts.set(channel, 0)` and `pausedChannels.delete(channel)`. On a working channel the daemon's own bookkeeping — checkpoint banners, "Step N completed", claim notices, resource grants — lands about once a minute, so the counter was reset faster than agents could reach the limit. The guard could effectively never fire on exactly the busy channel it protects.

System messages now route neutrally: same targets as before, `hopCounts` and `pausedChannels` untouched. Only a human or an explicit `@continue` resumes a channel. Delivery on a paused channel is deliberately unchanged, since a pause exists to stop agents answering each other, not to hide a stale-worker alert from the seat that must act on it.

**Consequence worth stating plainly:** channels will now actually pause after four agent-to-agent hops. That is the designed behaviour and has not been reachable in practice. Messages are still stored, so a seat watching a channel via `chat_wait` or `chat_read` still sees them; only the mention-triggered wakeup stops. `settings.chatMaxAgentHops` tunes the limit.

---

## Verification

| Check | Result |
|---|---|
| `chatChannelRef.test.ts` (new, 10 arms) | 10 passed |
| ...with commit 1's production change stashed | 7 failed, first with the quoted refusal |
| `mentionRouterSystemHops.test.ts` (new, 7 arms) | 7 passed |
| ...with commit 2's production change stashed | 4 failed, including the interleaved banner-between-hops arm |
| `packages/moe-daemon` full suite | 103 files, 1187 tests, all passed |
| `tsc --noEmit -p .` | exit 0 |

No existing test encoded either old behaviour: the `system` sender had no router coverage at all, and `mentionRouter.test.ts` plus `utilFixes.test.ts` are unchanged and green.

Not built: `prebuild` runs `clean` and would delete `dist/` under the live daemon, so the rebuild and restart stay with the human. Both fixes reach seats at the next daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgdd8Fwk3EX4gm9pncxhR9