### PR TITLE
fix(roles): stop architects blocking on REPL silence before submit_plan

### DIFF
--- a/docs/roles/architect.md
+++ b/docs/roles/architect.md
@@ -23,10 +23,10 @@ You run in an interactive TUI by default. The human is at the keyboard — use t
 
 Do not interrogate the user on trivial tasks (single file, obvious change, DoD already says exactly what to do). And do not turn this into a back-and-forth design session — the goal is to remove the specific ambiguities blocking a clean plan, then submit it.
 
-Only call `moe.submit_plan` once the user has confirmed the approach (a "yes / go ahead / that's right" in the REPL is enough). If the user is unreachable or unresponsive and the task is genuinely ambiguous, fall back to `moe.report_blocked` rather than speculating.
+Only wait for the user to confirm the approach in `CONTROL` mode, and only while they are actually answering. Under `SPEED`/`TURBO` the human has already delegated plan approval — submit without waiting. Never `moe.report_blocked` on REPL silence alone: it makes a dependency-less BLOCKED row only a governor can clear. Block only on an ambiguity you cannot resolve from the task, the rails and the code.
 
 ## Runtime-driven workflow
-Follow `nextAction` on every Moe tool response. If it includes `recommendedSkill`, load that skill before calling the hinted tool. Ownership, ordering, context fetches, and approval flow are enforced by the runtime; do not duplicate the old procedural checklist here. On `MoeError`, read `error.data.nextAction` and do what it says. If requirements are ambiguous or rails conflict, use `moe.report_blocked` instead of submitting a speculative plan.
+Follow `nextAction` on every Moe tool response. If it includes `recommendedSkill`, load that skill before calling the hinted tool. Ownership, ordering, context fetches, and approval flow are enforced by the runtime; do not duplicate the old procedural checklist here. On `MoeError`, read `error.data.nextAction` and do what it says. If requirements are ambiguous or rails conflict, use `moe.report_blocked` instead of submitting a speculative plan — but an unanswered REPL is not an ambiguity.
 
 ## Idle behavior
 

--- a/packages/moe-daemon/src/generated/initFiles.ts
+++ b/packages/moe-daemon/src/generated/initFiles.ts
@@ -18,7 +18,7 @@ import { atomicWriteText } from '../util/atomicWrite.js';
  * marker line — that opts the file out of future auto-upgrades.
  */
 export const ROLE_DOCS: Record<string, string> = {
-  'architect.md': `<!-- moe-generated: sha=10f85ae26bfe -->
+  'architect.md': `<!-- moe-generated: sha=36c12e0f6b86 -->
 
 # Architect
 
@@ -45,10 +45,10 @@ You run in an interactive TUI by default. The human is at the keyboard — use t
 
 Do not interrogate the user on trivial tasks (single file, obvious change, DoD already says exactly what to do). And do not turn this into a back-and-forth design session — the goal is to remove the specific ambiguities blocking a clean plan, then submit it.
 
-Only call \`moe.submit_plan\` once the user has confirmed the approach (a "yes / go ahead / that's right" in the REPL is enough). If the user is unreachable or unresponsive and the task is genuinely ambiguous, fall back to \`moe.report_blocked\` rather than speculating.
+Only wait for the user to confirm the approach in \`CONTROL\` mode, and only while they are actually answering. Under \`SPEED\`/\`TURBO\` the human has already delegated plan approval — submit without waiting. Never \`moe.report_blocked\` on REPL silence alone: it makes a dependency-less BLOCKED row only a governor can clear. Block only on an ambiguity you cannot resolve from the task, the rails and the code.
 
 ## Runtime-driven workflow
-Follow \`nextAction\` on every Moe tool response. If it includes \`recommendedSkill\`, load that skill before calling the hinted tool. Ownership, ordering, context fetches, and approval flow are enforced by the runtime; do not duplicate the old procedural checklist here. On \`MoeError\`, read \`error.data.nextAction\` and do what it says. If requirements are ambiguous or rails conflict, use \`moe.report_blocked\` instead of submitting a speculative plan.
+Follow \`nextAction\` on every Moe tool response. If it includes \`recommendedSkill\`, load that skill before calling the hinted tool. Ownership, ordering, context fetches, and approval flow are enforced by the runtime; do not duplicate the old procedural checklist here. On \`MoeError\`, read \`error.data.nextAction\` and do what it says. If requirements are ambiguous or rails conflict, use \`moe.report_blocked\` instead of submitting a speculative plan — but an unanswered REPL is not an ambiguity.
 
 ## Idle behavior
 


### PR DESCRIPTION
## The defect

`docs/roles/architect.md` told architects to call `moe.submit_plan` only after a human confirms the approach in the REPL, and to fall back to `moe.report_blocked` when "the user is unreachable or unresponsive."

That assumes one architect seat with a human watching it. The fleet runs three at once, so seats block on a keyboard that is attending a different window. And the doc's own escape hatch is what generates the work: a non-resource `report_blocked` produces a BLOCKED row with no `blockedOnTaskIds` and no `blockedResourceId`, which nothing auto-clears, so each one needs a governor to hand-clear it.

Five blocks on 2026-09-10 had this single cause, all phrased the same way, "Required human REPL approach confirmation before submit_plan has not been received":

| Task | Ruled by |
|---|---|
| task-4068aee4 | governor-2ad0ce48, 17:57 |
| task-7265e1fc | governor-2ad0ce48, 17:57 |
| task-aec72949 | carried the same REPL note |
| task-0d11e05f | carried the same REPL note |
| task-e7f534f1 | governor-c9adec43, 18:28 |

The rule also never consulted `approvalMode`, so it fired identically under `TURBO`, where the project has already configured plans to auto-approve. The seat was waiting for a gate the human had deliberately removed.

## The fix

Gate the confirmation on `CONTROL` mode and on the user actually answering, and say plainly that REPL silence is not a blocker. The runtime-workflow paragraph gets the same qualifier so the two cannot be read against each other.

## Verification

- `npm run lint` passes; `architect.md` is 38 lines against the 40 cap.
- Daemon `prebuild` restamped the vendored copy. The generated diff is confined to the `architect.md` entry and its sha.
- `npx vitest run src/util/initFiles.test.ts src/tools/initProject.test.ts src/util/qaCommitPolicy.test.ts src/commands/doctor.test.ts` gives 4 files, 21 tests, 0 failures.

## Notes for the reviewer

Approved by the project owner before pushing, since it changes when a role may call `submit_plan`.

The commit is built directly on `main` rather than branched off the live fleet branch, which carries 12 unrelated in-flight checkpoint commits. The `initFiles.ts` hunk was patched to touch only the `architect.md` entry: a straight regeneration would also have carried a peer's in-flight `qa.md` and `qa.reference.md` restamp onto `main` without their source docs.

Live seats keep the prompt they spawned with, so this reaches architects at their next spawn. No worker was restarted for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdBVdLx11Q9pAGFri6yEhb
