### PR TITLE
fix(daemon): let a purged governor re-enter governance

### DIFF
--- a/packages/moe-daemon/src/tools/enterGovernance.test.ts
+++ b/packages/moe-daemon/src/tools/enterGovernance.test.ts
@@ -50,6 +50,15 @@ describe('moe.enter_governance', () => {
     return worker;
   }
 
+  /** Push a live record past the 120s presence window so the purge evicts it. */
+  function ageWorker(workerId: string): void {
+    const worker = state.getWorker(workerId)!;
+    state.workers.set(workerId, {
+      ...worker,
+      lastActivityAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    });
+  }
+
   async function bindWorkerToTeamRole(workerId: string, role: TeamRole): Promise<void> {
     const team = await state.createTeam({ name: `${role}s`, role });
     await state.addTeamMember(team.id, workerId);
@@ -72,6 +81,56 @@ describe('moe.enter_governance', () => {
     const tool = enterGovernanceTool(state);
     await expect(tool.handler({ workerId: 'ghost' }, state))
       .rejects.toThrow(/not found|NOT_FOUND/i);
+  });
+
+  it('re-enters governance after a daemon restart purged the worker record', async () => {
+    // The regression: purgeAllWorkers runs on every daemon (re)start. It
+    // deletes every worker record and empties team memberIds, tombstoning each
+    // evicted id on the team. A governor session that outlives the restart then
+    // could not get back in — enter_governance threw WORKER_NOT_FOUND, and it
+    // is the only entry point the governor wrapper calls.
+    writeWorker({ id: 'governor-1', status: 'GOVERNING', currentTaskId: null });
+    await state.load();
+    await bindWorkerToTeamRole('governor-1', 'governor');
+    const teamId = state.getTeamForWorker('governor-1')!.id;
+    // Age the record AFTER binding — addTeamMember refreshes lastActivityAt.
+    // The purge keeps a registration still heartbeating inside the presence
+    // window, so only a governor quiet past it is actually evicted: a seat
+    // parked in a long chat_wait with no heartbeat sidecar, or one caught by
+    // deregister / the DEAD prune.
+    ageWorker('governor-1');
+
+    await state.purgeAllWorkers();
+    expect(state.getWorker('governor-1')).toBeNull();
+    expect(state.getTeam(teamId)!.memberIds).toEqual([]);
+    expect(state.getTeam(teamId)!.formerMemberIds).toContain('governor-1');
+
+    const tool = enterGovernanceTool(state);
+    const result = await tool.handler({ workerId: 'governor-1' }, state) as Record<string, unknown>;
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('GOVERNING');
+    expect(state.getWorker('governor-1')!.status).toBe('GOVERNING');
+    // Durable membership is restored, not left as a solo, so the role gate
+    // still passes on the next re-entry.
+    expect(state.getTeam(teamId)!.memberIds).toContain('governor-1');
+    expect(state.getWorker('governor-1')!.teamId).toBe(teamId);
+  });
+
+  it('still refuses a purged NON-governor record', async () => {
+    // The tombstone must not become a way in for the wrong role: an architect
+    // evicted by the same purge is refused exactly as a live one is.
+    writeWorker({ id: 'architect-1', status: 'IDLE' });
+    await state.load();
+    await bindWorkerToTeamRole('architect-1', 'architect');
+    ageWorker('architect-1');
+    await state.purgeAllWorkers();
+
+    const tool = enterGovernanceTool(state);
+    await expect(tool.handler({ workerId: 'architect-1' }, state))
+      .rejects.toThrow(/governor-only|NOT_ALLOWED/i);
+    // No record may be conjured for a role that cannot govern.
+    expect(state.getWorker('architect-1')).toBeNull();
   });
 
   it('rejects architect (or any non-governor worker) with NOT_ALLOWED', async () => {

--- a/packages/moe-daemon/src/tools/enterGovernance.ts
+++ b/packages/moe-daemon/src/tools/enterGovernance.ts
@@ -3,6 +3,7 @@ import type { StateManager } from '../state/StateManager.js';
 import type { ChatChannel } from '../types/schema.js';
 import { missingRequired, notFound, notAllowed } from '../util/errors.js';
 import { releaseWorkerTasks } from '../state/workerLifecycle.js';
+import { healTeamMembership, resolveEffectiveTeam } from '../util/teamMembershipHeal.js';
 import { logger } from '../util/logger.js';
 
 const GOVERNANCE_DUTIES = [
@@ -31,22 +32,51 @@ export function enterGovernanceTool(_state: StateManager): ToolDefinition {
         throw missingRequired('workerId');
       }
 
+      // Resolve membership through the eviction tombstone as well as the live
+      // record. Every daemon (re)start purges all worker records and empties
+      // team memberIds, so a governor mid-session loses both — and unlike every
+      // other role it has no way back: architects, workers and qa re-register
+      // through the wrapper's claim_next_task pre-flight (which heals via
+      // healTeamMembership), while the governor wrapper calls enter_governance
+      // exactly once at spawn. Looking the worker up and throwing therefore
+      // ended governance for the rest of the session. See
+      // util/teamMembershipHeal.ts.
       const worker = state.getWorker(params.workerId);
-      if (!worker) {
+      const team = resolveEffectiveTeam(state, params.workerId);
+      if (!worker && !team) {
         throw notFound('Worker', params.workerId);
       }
 
       // Role gate: only governors may enter governance mode. Architects plan,
       // workers code, qa verifies. Call moe.claim_next_task for your role
       // instead — architects on an empty PLANNING queue get a wait_for_task
-      // nextAction.
-      const team = state.getTeamForWorker(params.workerId);
+      // nextAction. The tombstone is durable state written by the purge, not
+      // caller input, so honouring it here does not widen who may govern.
       if (team?.role !== 'governor') {
         throw notAllowed(
           'enter_governance',
           'enter_governance is governor-only. Architects plan (use moe.claim_next_task with statuses:["PLANNING"], then moe.wait_for_task when empty); workers code; qa verifies. Join a governor team to govern.'
         );
       }
+
+      // Rebuild the record the purge deleted, then restore durable membership.
+      // healTeamMembership needs the record to exist and is a quiet no-op when
+      // membership is already live, so an ordinary re-entry emits no join.
+      if (!worker) {
+        await state.createWorker({
+          id: params.workerId,
+          type: 'CLAUDE',
+          projectId: state.project!.id,
+          epicId: '',
+          currentTaskId: null,
+          status: 'IDLE'
+        });
+        logger.info(
+          { workerId: params.workerId, teamId: team.id },
+          'enter_governance rebuilt a purged governor record from its team tombstone'
+        );
+      }
+      await healTeamMembership(state, params.workerId);
 
       // Hold the state mutex so concurrent enter_governance calls don't
       // double-broadcast or race on the worker update. We also re-check the


### PR DESCRIPTION
## The defect

`moe.enter_governance` looked the worker record up and threw `WORKER_NOT_FOUND` when it was missing. That record is not durable — `deleteWorker`, the DEAD-worker prune and the startup purge all delete it, and the startup purge runs on **every** daemon (re)start.

Every other role recovers on its own: the wrapper pre-flight calls `claim_next_task` on each fresh CLI spawn, and that path already rebuilds the record and restores membership via `healTeamMembership`. The governor wrapper calls `enter_governance` exactly once, at spawn. So a governor whose record was evicted mid-session had no way back in. Governance just ended, silently.

## Observed, not theorised

2026-09-11, this repo's own fleet. The daemon restarted at 09:32:24 under seven live seats. The governor session survived the restart, then:

```
moe.chat_send  → Invalid workerId: Unknown sender: workerId must be a
                 registered worker or "human"
enter_governance → [WORKER_NOT_FOUND] Worker not found: governor-983e1bae
```

The recovery tool refused the recovery. The seat only got back in through `moe.join_team`, which auto-registers. Nobody governed for twelve minutes, and nothing reported that.

## The fix

The tombstone this needs already exists. `purgeAllWorkers` and `deleteWorker` both record evicted ids in `Team.formerMemberIds` precisely so a returning worker rejoins its own team, and `util/teamMembershipHeal.ts` exposes `resolveEffectiveTeam` / `healTeamMembership` for it. `enter_governance` was the one entry point never wired to it.

It now resolves the team through the tombstone as well as live membership, rebuilds the purged record, and heals membership.

## The role gate does not widen

- A purged **architect** is refused exactly as a live one is, and **no record is created** for it. Covered by a test.
- An unknown id with no team at all still gets `WORKER_NOT_FOUND`. Existing test unchanged.
- A tombstone is durable state written by the daemon's own eviction path, never caller input.

## Relationship to 015ae81

015ae81 narrowed one cause — the startup purge now keeps registrations still heartbeating inside the presence window. It does not close the class. A governor parked in a long `chat_wait` without a heartbeat sidecar, or one hit by `deregister_worker` or the DEAD prune, is still evicted with no way back.

## Verification

| Check | Result |
|---|---|
| `npx vitest run` (this branch) | 103 files, 1192 tests, all pass |
| `npx tsc --noEmit` | clean |
| New regression tests | 2, both age the record past the presence window so they exercise the eviction that actually happens |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRXk5uscCHe2RYjM8VMZe8
