### PR TITLE
fix(blocks): clearing a block stops erasing the question, and an unanswered one carries itself forward

### DIFF
--- a/packages/moe-daemon/src/server/WebSocketServer.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.test.ts
@@ -421,6 +421,56 @@ describe('MoeWebSocketServer Integration', () => {
       ws.close();
     });
 
+    it('UPDATE_TASK out of BLOCKED keeps the reason and logs a real unblock', async () => {
+      // 2026-09-11: a row carrying an unanswered PRODUCT_DECISION_REQUIRED block
+      // was dragged out of BLOCKED twice. The board path nulled the whole block
+      // record, so the next architect to claim it saw a clean PLANNING card with
+      // no trace of the question and correctly re-blocked it three times. The
+      // tool path already archives the prose into priorBlockedReason before
+      // clearing; the board path must not be the one place it is destroyed.
+      const REASON = 'PRODUCT_DECISION_REQUIRED: which installed policy is effective';
+      await state.updateTask('task-1', {
+        status: 'BLOCKED',
+        blockedReason: REASON,
+        blockedFromStatus: 'PLANNING',
+        blockedAt: new Date().toISOString(),
+      });
+
+      const { ws, ready, nextMessage } = connectAndCollect();
+      await ready;
+      await nextMessage(); // STATE_SNAPSHOT
+
+      // status + order together is the shape a card drag actually sends.
+      ws.send(JSON.stringify({
+        type: 'UPDATE_TASK',
+        payload: { taskId: 'task-1', updates: { status: 'PLANNING', order: 1011.4 } },
+      }));
+
+      const updated = (await nextTaskUpdated(nextMessage)).payload;
+      expect(updated.status).toBe('PLANNING');
+      // The OPERATIONAL fields still clear — a later grant or sweep must not
+      // act on a block that is gone.
+      expect(updated.blockedReason == null).toBe(true);
+      expect(updated.blockedAt == null).toBe(true);
+      expect(updated.blockedFromStatus == null).toBe(true);
+      // The prose survives, which is the whole point: the next claimer can see
+      // WHY it was parked and judge whether anything was actually decided.
+      expect(updated.priorBlockedReason).toBe(REASON);
+
+      const stored = state.getTask('task-1');
+      expect(stored?.status).toBe('PLANNING');
+      expect(stored?.priorBlockedReason).toBe(REASON);
+      expect(stored?.blockedReason == null).toBe(true);
+
+      // And the transition is named. A generic TASK_UPDATED told a reader
+      // neither that a block had been cleared nor by what.
+      const events = state.getActivityLog(50).filter((e) => e.taskId === 'task-1');
+      const unblock = events.find((e) => e.event === 'TASK_UNBLOCKED');
+      expect(unblock, 'board unblock must log TASK_UNBLOCKED, not a generic TASK_UPDATED').toBeDefined();
+
+      ws.close();
+    });
+
     it('RELEASE_TASK frees the task and idles the worker (board button path)', async () => {
       await state.createWorker({
         id: 'w-rel',

--- a/packages/moe-daemon/src/server/WebSocketServer.test.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.test.ts
@@ -468,6 +468,80 @@ describe('MoeWebSocketServer Integration', () => {
       const unblock = events.find((e) => e.event === 'TASK_UNBLOCKED');
       expect(unblock, 'board unblock must log TASK_UNBLOCKED, not a generic TASK_UPDATED').toBeDefined();
 
+      // This block had no pending lease and no unmet prerequisite, so nothing
+      // would ever have cleared it: the question is still open and the row
+      // carries it forward where get_context will show the next claimer.
+      expect(updated.reopenReason).toContain('UNANSWERED BLOCK');
+      expect(updated.reopenReason).toContain(REASON);
+
+      ws.close();
+    });
+
+    it('UPDATE_TASK out of a RESOURCE block carries no question forward', async () => {
+      // A queued lease clears this row by itself when the grant fires, so a
+      // manual exit loses nothing and a carried question would be noise.
+      await state.updateTask('task-1', {
+        status: 'BLOCKED',
+        blockedReason: 'waiting on full-suite-gate for the daemon leg',
+        blockedResourceId: 'full-suite-gate',
+        blockedFromStatus: 'WORKING',
+        blockedAt: new Date().toISOString(),
+      });
+
+      const { ws, ready, nextMessage } = connectAndCollect();
+      await ready;
+      await nextMessage();
+
+      ws.send(JSON.stringify({
+        type: 'UPDATE_TASK',
+        payload: { taskId: 'task-1', updates: { status: 'WORKING' } },
+      }));
+
+      const updated = (await nextTaskUpdated(nextMessage)).payload;
+      expect(updated.status).toBe('WORKING');
+      // Evidence still kept...
+      expect(updated.priorBlockedReason).toBe('waiting on full-suite-gate for the daemon leg');
+      // ...but not re-asked as an open question.
+      expect(updated.reopenReason == null || !String(updated.reopenReason).includes('UNANSWERED BLOCK')).toBe(true);
+
+      ws.close();
+    });
+
+    it('UPDATE_TASK out of a DEPENDENCY block carries no question while a prerequisite is unmet', async () => {
+      // The dependency sweep restores this row when task-2 lands, so again
+      // nothing is lost by a manual exit.
+      const prereq = await state.createTask({
+        epicId: 'epic-1',
+        title: 'prerequisite still open',
+        description: '',
+        definitionOfDone: [],
+        status: 'WORKING',
+      });
+      // Must be a LIVE task: isDependencySatisfied treats a missing id as
+      // satisfied, so a fabricated id would invert what this arm measures.
+      expect(state.getTask(prereq.id)?.status).toBe('WORKING');
+
+      await state.updateTask('task-1', {
+        status: 'BLOCKED',
+        blockedReason: `BUILD-ORDER BLOCK on ${prereq.id}`,
+        blockedOnTaskIds: [prereq.id],
+        blockedFromStatus: 'WORKING',
+        blockedAt: new Date().toISOString(),
+      });
+
+      const { ws, ready, nextMessage } = connectAndCollect();
+      await ready;
+      await nextMessage();
+
+      ws.send(JSON.stringify({
+        type: 'UPDATE_TASK',
+        payload: { taskId: 'task-1', updates: { status: 'WORKING' } },
+      }));
+
+      const updated = (await nextTaskUpdated(nextMessage)).payload;
+      expect(updated.status).toBe('WORKING');
+      expect(updated.reopenReason == null || !String(updated.reopenReason).includes('UNANSWERED BLOCK')).toBe(true);
+
       ws.close();
     });
 

--- a/packages/moe-daemon/src/server/WebSocketServer.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.ts
@@ -330,6 +330,11 @@ export class MoeWebSocketServer {
             }
           }
           // Validation + update inside mutex to prevent TOCTOU race
+          // Set when this edit takes the task OUT of BLOCKED, so the activity
+          // event is TASK_UNBLOCKED rather than a generic TASK_UPDATED that
+          // names neither the transition nor an actor. Declared at the mutex
+          // callback's scope because the update call that consumes it is here.
+          let unblockedFromBoard = false;
           const task = await this.withMutex(async () => {
             if ('status' in safeUpdates) {
               const existing = this.state.getTask(taskId);
@@ -367,6 +372,17 @@ export class MoeWebSocketServer {
                     }
                     safeUpdates = {
                       ...safeUpdates,
+                      // Archive the prose before clearing it, exactly as
+                      // setTaskStatus does. Nulling blockedReason outright
+                      // destroyed the only record of WHY the task was parked,
+                      // so a seat that claimed the row next saw a clean
+                      // PLANNING card and could not tell a resolved block from
+                      // an erased one. Measured 2026-09-11: one row was dragged
+                      // out of BLOCKED twice while its PRODUCT_DECISION_REQUIRED
+                      // question was still unanswered, and the architect
+                      // correctly re-blocked it three times because the board
+                      // left it no way to see that nothing had been decided.
+                      ...(existing.blockedReason ? { priorBlockedReason: existing.blockedReason } : {}),
                       blockedReason: null,
                       blockedResourceId: null,
                       blockedOnTaskIds: null,
@@ -374,6 +390,7 @@ export class MoeWebSocketServer {
                       blockedAt: null,
                       ...(newStatus === effectiveFrom ? { assignedWorkerId: existing.assignedWorkerId } : {}),
                     };
+                    unblockedFromBoard = true;
                   }
                   // Entering BLOCKED from the board parks the task in place:
                   // record the restore target and keep the assignee.
@@ -441,7 +458,11 @@ export class MoeWebSocketServer {
                 }
               }
             }
-            return this.state.updateTask(taskId, safeUpdates);
+            return this.state.updateTask(
+              taskId,
+              safeUpdates,
+              unblockedFromBoard ? 'TASK_UNBLOCKED' : undefined
+            );
           });
           this.safeSend(ws, JSON.stringify({ type: 'TASK_UPDATED', payload: task }));
           return;

--- a/packages/moe-daemon/src/server/WebSocketServer.ts
+++ b/packages/moe-daemon/src/server/WebSocketServer.ts
@@ -2,6 +2,7 @@
 // WebSocketServer - plugin + MCP proxy connections
 // =============================================================================
 
+import { carriedBlockQuestion } from '../state/dependencyUnblock.js';
 import { WebSocketServer as WSS, WebSocket } from 'ws';
 import type { IncomingMessage, Server as HttpServer } from 'http';
 import type { StateManager, StateChangeEvent } from '../state/StateManager.js';
@@ -366,6 +367,7 @@ export class MoeWebSocketServer {
                   // src/tools/setTaskStatus.ts.
                   if (existing.status === 'BLOCKED') {
                     const effectiveFrom = existing.blockedFromStatus ?? 'WORKING';
+                    const carriedQuestion = carriedBlockQuestion(this.state, existing);
                     if (newStatus !== effectiveFrom && newStatus !== 'ARCHIVED'
                       && !(VALID_TRANSITIONS[effectiveFrom] ?? []).includes(newStatus)) {
                       throw new Error(`Cannot move task from BLOCKED to ${newStatus}: it was blocked from ${effectiveFrom} and ${effectiveFrom} -> ${newStatus} is not legal. Un-block to ${effectiveFrom} first.`);
@@ -383,6 +385,15 @@ export class MoeWebSocketServer {
                       // correctly re-blocked it three times because the board
                       // left it no way to see that nothing had been decided.
                       ...(existing.blockedReason ? { priorBlockedReason: existing.blockedReason } : {}),
+                      // A block with no pending lease and no unmet prerequisite
+                      // had nothing that would ever clear it — it was a
+                      // question. Carry it forward as a plan input so the next
+                      // claimer is handed the open question instead of a clean
+                      // card, rather than relying on a human to notice.
+                      // A reason the client supplied wins: it has spoken.
+                      ...(carriedQuestion && !safeUpdates.reopenReason
+                        ? { reopenReason: carriedQuestion }
+                        : {}),
                       blockedReason: null,
                       blockedResourceId: null,
                       blockedOnTaskIds: null,

--- a/packages/moe-daemon/src/state/dependencyUnblock.ts
+++ b/packages/moe-daemon/src/state/dependencyUnblock.ts
@@ -47,6 +47,40 @@ export function unmetBlockedOnTaskIds(state: StateManager, task: Pick<Task, 'blo
 }
 
 /**
+ * Prose to carry forward when a block is cleared by hand, or null when nothing
+ * needs carrying.
+ *
+ * A block that names a `blockedResourceId`, or that still has unmet
+ * prerequisites, clears ITSELF: the lease grant or the dependency sweep
+ * restores the row, so a manual exit loses nothing. A block with neither has
+ * nothing that will ever clear it on its own — it was a QUESTION. Clearing that
+ * one silently hands the next claimer a clean card with no trace of what was
+ * asked.
+ *
+ * Measured 2026-09-11: a row carrying an unanswered PRODUCT_DECISION_REQUIRED
+ * block was moved out of BLOCKED twice from the board. Each time the architect
+ * re-claimed it, found no answer, and blocked again — three blocks in four
+ * minutes — because nothing on the row said the question was still open. The
+ * row carrying its own open question forward is what removes the human from
+ * that loop; noticing and re-asking is what we are replacing.
+ */
+export function carriedBlockQuestion(
+  state: StateManager,
+  task: Pick<Task, 'blockedReason' | 'blockedResourceId' | 'blockedOnTaskIds'>
+): string | null {
+  if (!task.blockedReason) return null;
+  // Self-clearing: a grant or the dependency sweep will restore this row, so
+  // the block needs no carry-forward and saying otherwise would be noise.
+  if (task.blockedResourceId) return null;
+  if (unmetBlockedOnTaskIds(state, task).length > 0) return null;
+  return 'UNANSWERED BLOCK, carried forward. This row left BLOCKED with nothing '
+    + 'that would have cleared it on its own: no resource lease was pending and '
+    + 'no prerequisite was unmet. Treat what follows as an OPEN question, not as '
+    + 'history, and do not plan past it on a guess — re-block if it is still '
+    + 'unanswered. ' + task.blockedReason;
+}
+
+/**
  * Every outgoing dependency edge of a task: dependsOn ∪ blockedOnTaskIds. Both
  * fields gate the same thing (this row cannot progress until the target is
  * DONE/ARCHIVED), so a cycle through either — or a mix — starves identically.

--- a/packages/moe-daemon/src/tools/getContext.ts
+++ b/packages/moe-daemon/src/tools/getContext.ts
@@ -296,6 +296,11 @@ export function getContextTool(_state: StateManager): ToolDefinition {
               assignedWorkerId: task.assignedWorkerId,
               reopenCount: task.reopenCount,
               reopenReason: task.reopenReason,
+              // Surfaced even when the row is no longer BLOCKED: the block
+              // quartet below is status-gated, so without this a cleared block
+              // leaves no readable trace and the claimer cannot tell a resolved
+              // block from an erased one.
+              ...(task.priorBlockedReason ? { priorBlockedReason: task.priorBlockedReason } : {}),
               rejectionDetails: task.rejectionDetails || null,
               // Epic-final flag (drives the wrapper's qualityGate scope) and
               // dependency surface: declared prerequisites plus, on a BLOCKED

--- a/packages/moe-daemon/src/tools/setTaskStatus.test.ts
+++ b/packages/moe-daemon/src/tools/setTaskStatus.test.ts
@@ -76,6 +76,63 @@ describe('moe.set_task_status', () => {
     expect(task?.reopenReason).toBe('Fix needed');
   });
 
+  describe('an unblock with no reason carries the open question forward', () => {
+    it('carries a question-shaped block into reopenReason', async () => {
+      const tool = setTaskStatusTool(h.state);
+      await tool.handler({ taskId: 'task-1', status: 'PLANNING' }, h.state);
+      await tool.handler({
+        taskId: 'task-1', status: 'BLOCKED',
+        reason: 'PRODUCT_DECISION_REQUIRED: which installed policy is effective',
+      }, h.state);
+
+      // No reason on the way out — the shape that erased the question.
+      await tool.handler({ taskId: 'task-1', status: 'PLANNING' }, h.state);
+
+      const task = h.state.getTask('task-1')!;
+      expect(task.status).toBe('PLANNING');
+      expect(task.blockedReason == null).toBe(true);
+      expect(task.priorBlockedReason).toContain('PRODUCT_DECISION_REQUIRED');
+      // get_context shows reopenReason but status-gates the block quartet, so
+      // this is the field that actually reaches the next claimer.
+      expect(task.reopenReason).toContain('UNANSWERED BLOCK');
+      expect(task.reopenReason).toContain('PRODUCT_DECISION_REQUIRED');
+    });
+
+    it('does not overwrite a reason the caller supplied', async () => {
+      // The governor-ruling path: an unblock that states the answer must keep
+      // stating the answer, not be replaced by a generic "still open" notice.
+      const tool = setTaskStatusTool(h.state);
+      await tool.handler({ taskId: 'task-1', status: 'PLANNING' }, h.state);
+      await tool.handler({
+        taskId: 'task-1', status: 'BLOCKED', reason: 'PRODUCT_DECISION_REQUIRED: reset semantics',
+      }, h.state);
+
+      await tool.handler({
+        taskId: 'task-1', status: 'PLANNING',
+        reason: 'HUMAN RULING: an opt-in-free install is a reset boundary.',
+      }, h.state);
+
+      const task = h.state.getTask('task-1')!;
+      expect(task.reopenReason).toBe('HUMAN RULING: an opt-in-free install is a reset boundary.');
+      expect(task.reopenReason).not.toContain('UNANSWERED BLOCK');
+      // The evidence of what was asked survives either way.
+      expect(task.priorBlockedReason).toContain('reset semantics');
+    });
+
+    it('stays quiet for a resource block, which clears itself', async () => {
+      const tool = setTaskStatusTool(h.state);
+      await tool.handler({ taskId: 'task-1', status: 'PLANNING' }, h.state);
+      await tool.handler({ taskId: 'task-1', status: 'BLOCKED', reason: 'queued on full-suite-gate' }, h.state);
+      await h.state.updateTask('task-1', { blockedResourceId: 'full-suite-gate' });
+
+      await tool.handler({ taskId: 'task-1', status: 'PLANNING' }, h.state);
+
+      const task = h.state.getTask('task-1')!;
+      expect(task.reopenReason == null || !task.reopenReason.includes('UNANSWERED BLOCK')).toBe(true);
+      expect(task.priorBlockedReason).toContain('full-suite-gate');
+    });
+  });
+
   describe('BLOCKED transitions', () => {
     it('WORKING → BLOCKED preserves the assignment and records the restore target', async () => {
       await h.state.updateTask('task-1', { status: 'WORKING', assignedWorkerId: 'worker-1' });

--- a/packages/moe-daemon/src/tools/setTaskStatus.ts
+++ b/packages/moe-daemon/src/tools/setTaskStatus.ts
@@ -1,3 +1,4 @@
+import { carriedBlockQuestion } from '../state/dependencyUnblock.js';
 import type { ToolDefinition } from './index.js';
 import type { StateManager } from '../state/StateManager.js';
 import type { ActivityEventType, TaskStatus } from '../types/schema.js';
@@ -205,6 +206,12 @@ export function setTaskStatusTool(_state: StateManager): ToolDefinition {
 
       if (params.reason) {
         updates.reopenReason = params.reason;
+      } else if (task.status === 'BLOCKED' && newStatus !== 'BLOCKED') {
+        // No reason given for an unblock. If the block had nothing that would
+        // have cleared it on its own, the question it asked is still open, so
+        // the row carries it forward as a plan input rather than vanishing.
+        const carried = carriedBlockQuestion(state, task);
+        if (carried) updates.reopenReason = carried;
       }
 
       // A human moving a task that is parked for human review IS the review


### PR DESCRIPTION
Owner ruling that shaped this: *"i want it as much self repairing as possible and less human in the loop .. it should be smart enough to handle"*. So there is **no confirmation dialog and no new gate**. The daemon re-derives whether the block it is clearing was ever going to clear itself, and when it was not, the row carries the question forward on its own.

## The incident

`task-3ccb12a9` carried an unanswered `PRODUCT_DECISION_REQUIRED` block: an architect had measured that preview and release disagree on which installed policy is effective, and asked for a ruling. The row was then moved out of `BLOCKED` to `PLANNING` twice from the board, at 09:30:47 and 09:31:52. Each time the architect re-claimed it, read the row, found no answer and only its own explicitly unconfirmed proposal, and blocked again. **Three blocks in four minutes.** In its own words: *"a status move is not confirmation of authority semantics."*

Two things made those flips unreadable:

- The whole block record was nulled, `blockedReason` included, so the next claimer saw a clean `PLANNING` card. There was no way to tell a resolved block from an erased one.
- The activity event was a generic `TASK_UPDATED` with no actor, so the log said only *"Task moved to PLANNING by unknown"*.

## `1ca2de6` — stop erasing the evidence

`src/tools/setTaskStatus.ts` already got this right, and says why: *"the reason is inert text, and nulling it outright destroyed the only record of why the task was parked."* It copies `blockedReason` into `priorBlockedReason`, clears the operational fields, and logs `TASK_UNBLOCKED`. The board path did neither, so it now mirrors it. Operational fields still clear, because a later grant or sweep must not act on a block that is gone. A blocked `REVIEW`/`DONE`/`ARCHIVED` drag keeps returning `TASK_REOPENED`, matching `setTaskStatus`'s precedence.

## `f6bb119` — and carry an unanswered question forward

`carriedBlockQuestion()` in `state/dependencyUnblock.ts` states the rule once, beside the dependency predicates it reuses:

| Block shape | Clears itself? | Carried forward |
|---|---|---|
| `blockedResourceId` set | yes, on lease grant | nothing |
| unmet `blockedOnTaskIds` | yes, on the dependency sweep | nothing |
| neither | **never** | the question |

Wired into **both** exits from `BLOCKED` so behaviour does not depend on the path: `setTaskStatus` when the caller gives no reason, and the board path with the same precedence. A reason the caller *did* give always wins, because the governor-ruling path must keep stating the answer rather than being overwritten by a generic "still open".

The prose lands in `reopenReason` specifically: `get_context` status-gates the block quartet, so the instant a row leaves `BLOCKED` a claimer could see nothing at all, and `reopenReason` is the field that actually reaches them. `get_context` now also surfaces `priorBlockedReason` regardless of status.

Under this change the first board unblock would have handed the architect *"UNANSWERED BLOCK, carried forward …"* as a plan input, and that loop needs no governor in it.

**Deliberately unchanged:** the board may still move a `BLOCKED` card wherever the transition table allows. Refusing the gesture would add a human step, which is the opposite of the ruling.

## Verification

| Check | Result |
|---|---|
| New arms (5) | board: human-block carries, resource block quiet, dependency block quiet; tool: carries, caller reason survives |
| `WebSocketServer.test.ts` BLOCKED arm without `1ca2de6` | fails: `expected undefined to be 'PRODUCT_DECISION_REQUIRED …'` |
| `packages/moe-daemon` full suite | 103 files, 1196 tests, all passed |
| `tsc --noEmit -p .` | exit 0 |

One earlier run showed a single red in `waitForTask.test.ts`'s resource-block parking arm. It is a load flake, not this diff, and the attribution was measured rather than assumed: that suite passes 10/10 in isolation with these changes, a clean tree at `1ca2de6` passes 1191/1191, and a second full run with the changes passes 1196/1196.

Not built: `prebuild` runs `clean` and would delete `dist/` under the live daemon, so the rebuild and restart stay with the human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgdd8Fwk3EX4gm9pncxhR9