### PR TITLE
fix(daemon): stop downstream plan intent from contesting a task's landing

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -460,7 +460,9 @@ Mark a task as `REVIEW` (complete) and optionally attach a PR link. Requires tas
   touchedFiles: string[],
   inferredPaths: string[],
   unattributedPaths: string[],
-  peerDeclared: { path: string, taskId: string }[],   // the same union over every OTHER task with status ∉ {DONE, ARCHIVED}
+  peerDeclared: { path: string, taskId: string }[],   // the same union over every OTHER task with status ∉ {DONE, ARCHIVED} —
+                              // except a peer that waits on this task (dependsOn ∪ blockedOnTaskIds, transitively) contributes its
+                              // asserted paths only: dependsOn gates it from WORKING until this task is DONE, so its plan is intent, not an edit
   livePeerIds: string[],      // workers ≠ caller, not DEAD, lastActivityAt inside the window (or registered since `since`)
   activePeerIds: string[],
   peersActive: boolean,

--- a/packages/moe-daemon/src/tools/getCommitScope.test.ts
+++ b/packages/moe-daemon/src/tools/getCommitScope.test.ts
@@ -143,6 +143,64 @@ describe('moe.get_commit_scope', () => {
     expect(byPath.has(pathKey('src/mine.ts'))).toBe(false);
   });
 
+  it('ignores the plan-declared paths of a peer that waits on this task, but keeps its asserted ones', async () => {
+    // The regression (task-435683c2, 2026-09-11): every link of a serialized
+    // chain declares the same shared files in its plan. A downstream link that
+    // waits on the landing task cannot have run yet - dependsOn gates its
+    // WORKING claims until the landing task is DONE - yet its plan intent was
+    // counted as a peer claim, contested the landing task's own edits, and held
+    // that task's entire diff out of its completion commit.
+    h.setupMoeFolder();
+    h.createEpic();
+    h.createTask({ id: 'task-1', status: 'REVIEW', implementationPlan: [
+      { stepId: 's1', description: 'a', status: 'COMPLETED', affectedFiles: ['src/shared.ts'] },
+    ] });
+    // Direct dependent: plan declares the same file, and has done no work.
+    h.createTask({ id: 'task-d1', status: 'WORKING', dependsOn: ['task-1'], implementationPlan: [
+      { stepId: 's1', description: 'd1', status: 'PENDING', affectedFiles: ['src/shared.ts', 'src/d1-plan.ts'] },
+    ] });
+    // Transitive dependent, through task-d1.
+    h.createTask({ id: 'task-d2', status: 'WORKING', dependsOn: ['task-d1'], implementationPlan: [
+      { stepId: 's1', description: 'd2', status: 'PENDING', affectedFiles: ['src/d2-plan.ts'] },
+    ] });
+    // Waits through a runtime block instead of dependsOn, and carries real
+    // evidence of an edit (declare_files) alongside plan intent.
+    h.createTask({
+      id: 'task-d3', status: 'BLOCKED', blockedOnTaskIds: ['task-1'], declaredFiles: ['src/d3-asserted.ts'],
+      implementationPlan: [{ stepId: 's1', description: 'd3', status: 'PENDING', affectedFiles: ['src/d3-plan.ts'] }],
+    });
+    await h.state.load();
+
+    const byPath = new Map((await scope()).peerDeclared.map((e) => [pathKey(e.path), e.taskId]));
+    expect(byPath.has(pathKey('src/shared.ts'))).toBe(false);
+    expect(byPath.has(pathKey('src/d1-plan.ts'))).toBe(false);
+    expect(byPath.has(pathKey('src/d2-plan.ts'))).toBe(false);
+    expect(byPath.has(pathKey('src/d3-plan.ts'))).toBe(false);
+    // Asserted evidence of a real edit still contests, even from a dependent.
+    expect(byPath.get(pathKey('src/d3-asserted.ts'))).toBe('task-d3');
+  });
+
+  it('still counts the plan-declared paths of a prerequisite and of an unrelated peer', async () => {
+    h.setupMoeFolder();
+    h.createEpic();
+    h.createTask({ id: 'task-pre', status: 'WORKING', implementationPlan: [
+      { stepId: 's1', description: 'pre', status: 'PENDING', affectedFiles: ['src/pre.ts'] },
+    ] });
+    h.createTask({ id: 'task-1', status: 'WORKING', dependsOn: ['task-pre'], implementationPlan: [
+      { stepId: 's1', description: 'a', status: 'PENDING', affectedFiles: ['src/mine.ts'] },
+    ] });
+    h.createTask({ id: 'task-free', status: 'WORKING', implementationPlan: [
+      { stepId: 's1', description: 'f', status: 'PENDING', affectedFiles: ['src/free.ts'] },
+    ] });
+    await h.state.load();
+
+    const byPath = new Map((await scope()).peerDeclared.map((e) => [pathKey(e.path), e.taskId]));
+    // task-1 waits on task-pre, not the other way round, so task-pre's plan is
+    // live intent from a task that may be editing right now.
+    expect(byPath.get(pathKey('src/pre.ts'))).toBe('task-pre');
+    expect(byPath.get(pathKey('src/free.ts'))).toBe('task-free');
+  });
+
   it('tolerates un-storable paths in a peer record instead of failing the scope', async () => {
     h.setupMoeFolder();
     h.createEpic();

--- a/packages/moe-daemon/src/tools/getCommitScope.ts
+++ b/packages/moe-daemon/src/tools/getCommitScope.ts
@@ -5,6 +5,7 @@ import { invalidInput, missingRequired, notFound } from '../util/errors.js';
 import { normalizeAffectedFiles } from '../util/affectedFiles.js';
 import { collectPeerPaths, collectTaskPathTiers, PathSet } from '../util/attributionTiers.js';
 import { isWorkerAlive, LIVENESS_TIMEOUT_MS } from '../util/workerLiveness.js';
+import { findDependencyPath } from '../state/dependencyUnblock.js';
 
 const PHASES = ['preflight', 'postflight'] as const;
 type ScopePhase = typeof PHASES[number];
@@ -33,7 +34,7 @@ function sortedById<T extends { id: string }>(items: Iterable<T>): T[] {
 export function getCommitScopeTool(_state: StateManager): ToolDefinition {
   return {
     name: 'moe.get_commit_scope',
-    description: 'Attribution scope the agent wrapper stages a task\'s commit from: the task\'s ASSERTED paths (completed steps\' modifiedFiles/affectedFiles, filesModified, declare_files, tool-written, previously committed), its PLANNED paths (plan-declared only, committed when changed since the pre-task baseline), every other open task\'s declared paths (PEER map), which workers are active (peersActive drives the attribution.undeclared policy), the board-state paths it may commit, and the project\'s commit policy. Read-only apart from a liveness touch; no ownership guard — an orphan-mode caller (workerId not the assignee) is counted in activePeerIds.',
+    description: 'Attribution scope the agent wrapper stages a task\'s commit from: the task\'s ASSERTED paths (completed steps\' modifiedFiles/affectedFiles, filesModified, declare_files, tool-written, previously committed), its PLANNED paths (plan-declared only, committed when changed since the pre-task baseline), every other open task\'s declared paths (PEER map; a peer that waits on this task contributes only its asserted paths, since it cannot have run yet), which workers are active (peersActive drives the attribution.undeclared policy), the board-state paths it may commit, and the project\'s commit policy. Read-only apart from a liveness touch; no ownership guard — an orphan-mode caller (workerId not the assignee) is counted in activePeerIds.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -88,7 +89,16 @@ export function getCommitScopeTool(_state: StateManager): ToolDefinition {
       for (const other of sortedById<Task>(state.tasks.values())) {
         if (other.id === task.id) continue;
         if (TERMINAL_STATUSES.has(other.status)) continue;
-        for (const p of collectPeerPaths(other)) {
+        // A peer that waits on THIS task (dependsOn or blockedOnTaskIds, followed
+        // transitively) cannot have run yet: dependsOn gates its WORKING claims
+        // until this task is DONE. Its plan-declared paths are forward intent,
+        // not concurrent edits. Counting them made every link of a serialized
+        // chain contest the link before it, and held that task's own diff out of
+        // its completion commit. Its ASSERTED paths are evidence of a real edit
+        // and still count.
+        const waitsOnThis = findDependencyPath(state, other.id, task.id) !== null;
+        const peerPaths = waitsOnThis ? collectTaskPathTiers(other).asserted : collectPeerPaths(other);
+        for (const p of peerPaths) {
           if (peerSet.has(p)) continue;
           const stored = peerSet.add(p);
           if (stored === null) continue;


### PR DESCRIPTION
## The defect

`moe.get_commit_scope` built its PEER map from **every** other open task's asserted and planned paths, with no regard to which way the dependency ran. In a serialized chain every link declares the same shared files in its plan, so each downstream link contested the edits of the link it is waiting on. The wrapper's default `contested: skip-untouched` then held that task's own diff out of its completion commit.

## Observed, 2026-09-11

task-435683c2 (JetBrains time-cap parser removal):

| Commit | What it carried |
|---|---|
| `e0ed8ca` feat, the worker's completion | the task's board JSON only (`Moe-Paths: 1`) |
| `e09bcb6` feat `[qa self-land]` | the actual code: Models.kt, MoeJson.kt, MoeJsonTest.kt (+240), MoeProjectService.kt |

All four source files were skipped as contested. The contest came from the plans of task-e7f534f1 and task-0ad3744e, and **both depend on task-435683c2**, so neither had started: every step PENDING, no commits. A peer that could not run yet was blocking the landing of the task it waits for. The daemon still recorded a completion, so nothing looked wrong until QA inspected the trailers and landed the code by hand. Without that the bytes would have stranded at DONE, then been committed later under a downstream task's id.

It is queued at every remaining link: task-0ad3744e depends on task-e7f534f1 and declares the same Models.kt and MoeJson.kt. QA (qa-813933f7) diagnosed the mechanism and proposed this rule.

## The fix

A peer that waits on the landing task (dependsOn ∪ blockedOnTaskIds, followed transitively) cannot have run yet, because dependsOn gates its WORKING claims until the landing task is DONE. Its plan-declared paths are intent, not concurrent edits, so it now contributes **only its ASSERTED paths**.

- **Asserted evidence still contests.** Completed-step files, `declare_files`, tool-written paths and prior commits all still count, including from a dependent. There's a test for it.
- **Prerequisites and unrelated peers are unchanged.** There's a test for that too.
- **It reuses `findDependencyPath`**, the helper the three dependency writers already use for cycle detection. No new graph walk.

## Deliberately not changed

The wrappers' **daemon-unreachable fallback** rebuilds the peer map itself in `moe-agent.sh` / `moe-agent.ps1`. It stays maximally conservative on purpose. Without the daemon it can't see liveness either, and leaving bytes dirty for the next connected session is the safe failure there. Changing it would also mean editing both twin launchers, which is out of proportion here.

## Verification

| Check | Result |
|---|---|
| New red test | fails on the old code, passes after |
| `npx vitest run`, two consecutive full runs | 103 files, 1192 tests, all passing |
| `npx tsc --noEmit` | clean |

One earlier full run showed **3 failures in 2 files that did not reproduce**. It ran while a live fleet was running vitest and Gradle on the same box. I didn't capture the test names, so I can't rule out a flake elsewhere in the suite. The change is a pure function over in-memory state and the two runs after it were clean.

## Reaching the fleet

The live daemon is the installed JetBrains plugin snapshot, so this reaches running fleets only after a plugin rebuild and reinstall. Until then, QA must keep checking the `Moe-Paths` / `Moe-Contested` trailers on each completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
