### PR TITLE
fix(create_task): attribute createdBy by seat role, not team role alone

### DIFF
--- a/packages/moe-daemon/src/tools/createTask.test.ts
+++ b/packages/moe-daemon/src/tools/createTask.test.ts
@@ -84,6 +84,36 @@ describe('moe.create_task guardrails + attribution', () => {
       expect((await create({ title: 'D', workerId: 'governor-1', createdBy: 'HUMAN' })).task.createdBy).toBe('GOVERNOR');
     });
 
+    // REGRESSION 2026-09-11: the arm above seeds a team that HAS the role, so it
+    // never exercised the shape the launcher actually produces — one
+    // project-named team, `role: null`, holding seats of several roles at once.
+    // Reading `team.role` directly resolved to nothing there and every row an
+    // architect/QA/governor filed landed `createdBy: 'WORKER'`. Attribution now
+    // goes through util/workerRole, which falls back to the seat's id prefix.
+    it('attributes by id prefix when the shared team carries no role', async () => {
+      const mixed = await h.state.createTeam({ name: 'moe-next' });
+      expect(mixed.role).toBeFalsy(); // the launcher's team: no role at all
+      for (const id of ['architect-76be3b8c', 'qa-a8573597', 'governor-d7005695', 'worker-da0aeedb']) {
+        await h.state.createWorker({
+          id, type: 'CLAUDE', projectId: 'proj-test', epicId: 'epic-1',
+          currentTaskId: null, status: 'IDLE',
+        });
+        await h.state.addTeamMember(mixed.id, id);
+      }
+
+      expect((await create({ title: 'H', workerId: 'architect-76be3b8c' })).task.createdBy).toBe('ARCHITECT');
+      expect((await create({ title: 'I', workerId: 'qa-a8573597' })).task.createdBy).toBe('QA');
+      expect((await create({ title: 'J', workerId: 'governor-d7005695' })).task.createdBy).toBe('GOVERNOR');
+      expect((await create({ title: 'K', workerId: 'worker-da0aeedb' })).task.createdBy).toBe('WORKER');
+    });
+
+    // A team that DOES declare a role still wins over the id prefix: an explicit
+    // join_team onto a roled team is the operator stating the seat's role.
+    it('lets a roled team override the id prefix', async () => {
+      await addRoleWorker('worker-onqateam', 'qa');
+      expect((await create({ title: 'L', workerId: 'worker-onqateam' })).task.createdBy).toBe('QA');
+    });
+
     it('falls back to the explicit createdBy, then WORKER, for team-less callers', async () => {
       expect((await create({ title: 'E', createdBy: 'HUMAN' })).task.createdBy).toBe('HUMAN');
       expect((await create({ title: 'F', workerId: 'worker-unknown' })).task.createdBy).toBe('WORKER');

--- a/packages/moe-daemon/src/tools/createTask.ts
+++ b/packages/moe-daemon/src/tools/createTask.ts
@@ -5,6 +5,7 @@ import { missingRequired, invalidInput } from '../util/errors.js';
 import { MAX_TASK_DEPENDENCY_IDS } from '../state/taskStore.js';
 import { resolveMaxTasksPerEpic } from '../util/planSize.js';
 import { findDependencyPath, formatDependencyCycle } from '../state/dependencyUnblock.js';
+import { resolveWorkerRole } from '../util/workerRole.js';
 
 /**
  * Titles that read as meta/evidence/hardening rows — the shape behind measured
@@ -122,12 +123,18 @@ export function createTaskTool(_state: StateManager): ToolDefinition {
         dependsOn = known.length > 0 ? known : undefined;
       }
 
-      // Role attribution: resolve the caller's team role into createdBy
-      // (pattern: submit_plan_critique's role gate — but soft: an unknown or
-      // team-less caller just falls back to the explicit param / WORKER).
-      const team = params.workerId ? state.getTeamForWorker(params.workerId) : null;
+      // Role attribution: resolve the caller's role through util/workerRole —
+      // team role first, then the seat's id prefix — exactly as the role-GATED
+      // tools do. Reading `team.role` directly, as this once did, stamps WORKER
+      // on every row an architect, QA or governor files from a role-LESS team,
+      // and that is the team the launcher registers seats into: measured
+      // 2026-09-11 on moe-next, an architect-filed row landed
+      // `createdBy: "WORKER"` because the project-named team `moe-next` carries
+      // `role: null` and holds seats of three different roles at once.
+      // An unknown or workerId-less caller still falls back to the param / WORKER.
+      const resolvedRole = params.workerId ? resolveWorkerRole(state, params.workerId) : null;
       const resolvedCreatedBy: Task['createdBy'] =
-        (team?.role && ROLE_TO_CREATED_BY[team.role]) || params.createdBy || 'WORKER';
+        (resolvedRole && ROLE_TO_CREATED_BY[resolvedRole]) || params.createdBy || 'WORKER';
 
       // Column WIP limit at creation — WARNING ONLY. The transition path
       // (set_task_status / board) throws at the limit, but a creation must


### PR DESCRIPTION
## The report

An architect filing a bug row on the moe-next board got `createdBy: "WORKER"`. Reported by `architect-76be3b8c` on `task-2c827d67524c432989d338e3ede86716`, 2026-09-11, and measured rather than taken on trust.

## Cause

`create_task` resolved attribution by reading `team.role` directly:

```ts
const team = params.workerId ? state.getTeamForWorker(params.workerId) : null;
(team?.role && ROLE_TO_CREATED_BY[team.role]) || params.createdBy || 'WORKER'
```

The role-**gated** tools (`set_task_dependencies`, `amend_plan_step`, `submit_plan_critique`) stopped doing that on 2026-09-05 and went through `util/workerRole.resolveWorkerRole`, which falls back to the seat's id prefix when the team declares no role. `create_task` kept the direct read — its own comment cites `submit_plan_critique` as the pattern it follows, while reimplementing the half that was broken.

That fallback is not an edge case, it is the normal fleet shape. The launcher registers every seat into one project-named team, and on moe-next that team (`team-f2178c1f74704c72b927102498b5edd5`, name `moe-next`) carries `role: null` while holding an architect, a QA and a worker at once:

```json
{ "id": "team-f2178c1f...", "name": "moe-next", "role": null,
  "memberIds": ["worker-da0aeedb", "architect-76be3b8c", "qa-a8573597"] }
```

`team?.role` is null there for all three, so every row any of them files lands as `WORKER`. Board provenance is wrong for anything an architect, QA or governor creates.

## Fix

Resolve through `resolveWorkerRole`, exactly as the role gates do. Behaviour that does **not** change:

- a team that DOES declare a role still wins over the id prefix, so an explicit `join_team` onto a roled team keeps overriding the seat name;
- a `workerId`-less or unknown caller still falls back to the explicit `createdBy` param, then `WORKER`.

This is attribution metadata only — it changes nothing about what a seat may claim or do.

## Test gap this closes

The existing attribution test seeded a team that HAS the role, so it never covered the shape the launcher actually produces. Added one arm that builds the real thing — a single role-less team holding four seats of four roles — and one asserting a roled team still overrides the prefix.

## Verification

In `packages/moe-daemon`:

| Check | Result |
|---|---|
| `npx vitest run src/tools/createTask.test.ts` | **12 passed (12)**, was 10 |
| Mutation drill: resolution line reverted to the pre-fix direct team read | **1 failed \| 11 passed** — `AssertionError: expected 'WORKER' to be 'ARCHITECT'`, the reported symptom reproduced |
| `npx tsc --noEmit -p tsconfig.json` | **exit 0** |
| Full suite `npx vitest run` | 3 failed \| 1525 passed (1532) |

The 3 reds are in `src/tools/releaseTask.test.ts` (startup-purge attempt closing), are untouched by this change, and reproduce identically with both of my files stashed out — they belong to unrelated in-flight work in that checkout, not to this PR. Committed from a clean worktree off `origin/main` so none of that peer work could be swept in; the diff is two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Bu3SKMxU8HXfpSY9bzj7o
