### PR TITLE
docs(roles): stop the acknowledge-the-acknowledgement loop

### DIFF
--- a/docs/roles/architect.reference.md
+++ b/docs/roles/architect.reference.md
@@ -78,6 +78,15 @@ The wrapper lands a `wip(task-<id>): <title> [status=<STATUS> role=architect cli
 Cross-session memory lives in the Serena MCP server (`.serena/memories/`), not in Moe. On task start, `list_memories` / `read_memory` to pick up prior constraints and decisions. When you discover a non-obvious constraint, gotcha, or pattern during exploration, `write_memory` a `decision-<area>` / `gotcha-<area>` note (or `edit_memory` an existing one). Names are the only index — be consistent.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Confirmed: `retry-budget = 5`. Updating step 2 now."
 - "That step's rail is misread — `requiredPatterns` means the phrase must appear verbatim, not that the test must pass."

--- a/docs/roles/qa.reference.md
+++ b/docs/roles/qa.reference.md
@@ -31,6 +31,15 @@ Deep-dive material trimmed out of `qa.md`. Read this on demand; it is not loaded
 Cross-session memory lives in the Serena MCP server (`.serena/memories/`), not in Moe. When you find a recurring pattern or a subtle gap the tests didn't catch, `write_memory` a `gotcha-<area>` note (or `edit_memory` an existing one) so the next agent avoids it. Rejection `issues` you record on the task are already visible to the worker via `get_handoff_history`; use Serena memory for the broader, cross-task lesson.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Rejecting: `rejectionDetails[2]` — the nil-guard in `foo.ts:41` is missing. Reopening with a fix note."
 - "Approved: all DoD items verified, tests green on commit `abcd123`."

--- a/docs/roles/worker.reference.md
+++ b/docs/roles/worker.reference.md
@@ -101,6 +101,15 @@ Naming convention (keeps a multi-agent fleet's knowledge coherent — one topic,
 Prefer `edit_memory` to append to an existing topic file over creating a near-duplicate. There is no BM25 ranking or auto-injection — this naming discipline is what replaces it, so be consistent.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Step 2 is blocked on the `retry-budget` constant — do you want `5` or the env-var fallback?"
 - "Confirmed I own task-X; starting step 0 now."

--- a/packages/moe-daemon/src/generated/initFiles.ts
+++ b/packages/moe-daemon/src/generated/initFiles.ts
@@ -58,7 +58,7 @@ You do NOT govern in-flight workers. Oversight (drift scans, stale-worker handli
 
 ## Self-improvement: fix Moe itself
 Fix defects in Moe itself at the source; first read [the source-editing and delivery rules](architect.reference.md#self-improvement-fix-moe-itself). Keep fixes scoped, update both launchers when applicable, verify, and respect branch protection.`,
-  'architect.reference.md': `<!-- moe-generated: sha=c540e2042420 -->
+  'architect.reference.md': `<!-- moe-generated: sha=c16de6533b52 -->
 
 # Architect — Reference
 
@@ -140,6 +140,15 @@ The wrapper lands a \`wip(task-<id>): <title> [status=<STATUS> role=architect cl
 Cross-session memory lives in the Serena MCP server (\`.serena/memories/\`), not in Moe. On task start, \`list_memories\` / \`read_memory\` to pick up prior constraints and decisions. When you discover a non-obvious constraint, gotcha, or pattern during exploration, \`write_memory\` a \`decision-<area>\` / \`gotcha-<area>\` note (or \`edit_memory\` an existing one). Names are the only index — be consistent.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Confirmed: \`retry-budget = 5\`. Updating step 2 now."
 - "That step's rail is misread — \`requiredPatterns\` means the phrase must appear verbatim, not that the test must pass."
@@ -409,7 +418,7 @@ Follow \`nextAction\` on every Moe tool response. If it includes \`recommendedSk
 The runtime enforces review transitions; never move REVIEW back to BACKLOG. Use \`moe.qa_reject\` to send work back to WORKING.
 
 If intent is ambiguous, ask the assigned worker in the task channel before deciding.`,
-  'qa.reference.md': `<!-- moe-generated: sha=7a888e2b306e -->
+  'qa.reference.md': `<!-- moe-generated: sha=e8b6300b7f5b -->
 
 # QA — Reference
 
@@ -444,6 +453,15 @@ Deep-dive material trimmed out of \`qa.md\`. Read this on demand; it is not load
 Cross-session memory lives in the Serena MCP server (\`.serena/memories/\`), not in Moe. When you find a recurring pattern or a subtle gap the tests didn't catch, \`write_memory\` a \`gotcha-<area>\` note (or \`edit_memory\` an existing one) so the next agent avoids it. Rejection \`issues\` you record on the task are already visible to the worker via \`get_handoff_history\`; use Serena memory for the broader, cross-task lesson.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Rejecting: \`rejectionDetails[2]\` — the nil-guard in \`foo.ts:41\` is missing. Reopening with a fix note."
 - "Approved: all DoD items verified, tests green on commit \`abcd123\`."
@@ -475,7 +493,7 @@ The runtime enforces ownership, step ordering, and task completion gates, so rel
 Memory lives in Serena. On task start, \`list_memories\` then \`read_memory\` to pick up prior knowledge for this task/area. When you hit a non-obvious gotcha or convention worth keeping, \`write_memory\` named \`gotcha-<area>\` / \`convention-<area>\` (prefer \`edit_memory\` on an existing topic over a near-duplicate). Before you finish, \`write_memory\` a \`task-<id>-handoff\` note for the next agent.
 
 Use \`moe.report_blocked\` when rails conflict, prerequisites are missing, requirements are ambiguous, or a safe implementation cannot be verified. Blocking on another task landing? Pass its id(s) in \`blockedOnTaskIds\` — the daemon auto-unblocks when they are all DONE, and your seat is freed to claim other work meanwhile; if they are ALL already DONE the call answers \`dependenciesSatisfied:true\` and does not block — continue. BLOCKED is a wait state, never a terminal — delivered, green work goes through \`complete_task\`, not \`report_blocked\`.`,
-  'worker.reference.md': `<!-- moe-generated: sha=00d768586ec5 -->
+  'worker.reference.md': `<!-- moe-generated: sha=e6856d2d3801 -->
 
 # Worker — Reference
 
@@ -580,6 +598,15 @@ Naming convention (keeps a multi-agent fleet's knowledge coherent — one topic,
 Prefer \`edit_memory\` to append to an existing topic file over creating a near-duplicate. There is no BM25 ranking or auto-injection — this naming discipline is what replaces it, so be consistent.
 
 ## Mention reply examples
+Acknowledge ONCE. If the other side acks back, the thread is over — do not
+confirm a confirmation. A closure that needs restating was not a closure. If you
+have something NEW, say the new thing; if you only have agreement, stay silent
+and get back to your steps. Measured twice (2026-09-11 and 2026-09-12): two
+different pairs of seats each burned 3-7 messages and several minutes of live
+task time on "closed" / "confirmed closed" round-trips. The Loop Guard caps
+agent-to-agent hops per channel, but it cannot tell agreement from progress —
+only you can.
+
 
 - "Step 2 is blocked on the \`retry-budget\` constant — do you want \`5\` or the env-var fallback?"
 - "Confirmed I own task-X; starting step 0 now."


### PR DESCRIPTION
## The behaviour

Two different pairs of seats, on two consecutive days, spent live task time confirming that they agreed with each other.

**2026-09-11** — worker-f2b3ac93 and worker-e67b0dd2, seven messages between 09:46 and 09:49. Every one was some form of "acknowledged, thread closed, nothing outstanding, settled state recorded". Each "closed" prompted another "confirmed closed".

**2026-09-12** — worker-85674160 and worker-e67b0dd2, the same loop again: ~3,500 characters of "closed on all three" / "Confirmed closed on all three".

The content was never in dispute in either case. Both threads were finished at the first acknowledgement. Everything after that was ceremony, paid for out of the sessions of seats that were mid-task.

## Why chat could not fix it

A governor told the first pair to stop, in chat, on the 11th. The second pair were **different seats that had never read it**. Agents here are spawned fresh per task and chat does not survive a session boundary, so a correction delivered in chat expires the moment the seat does.

That is what makes this a source fix rather than another chat message. The guidance has to live where a new session actually looks.

## The change

One paragraph added to the **"Mention reply examples"** section of `worker.reference.md`, `qa.reference.md` and `architect.reference.md` — the section an agent reads when deciding what to say in chat.

The rule: acknowledge once; an ack back ends the thread; never confirm a confirmation; say a NEW thing or stay silent. It names the Loop Guard explicitly so nobody mistakes it for a safety net — the guard caps agent-to-agent hops per channel, but it cannot tell agreement from progress.

## Constraints respected

- **Only `.reference.md` files are touched**, so the hard 40-line cap on the three terse role docs is untouched. `npm run lint` passes: worker 25, qa 25, architect 38.
- **`src/generated/initFiles.ts` is regenerated via `npm run prebuild`**, not hand-edited, so projects receive this on their next daemon upgrade. `skillFiles.ts` regenerated to no diff.

## Verification

| Check | Result |
|---|---|
| `npm run lint` (role-doc linter) | clean |
| `npx vitest run` | 103 files, 1190 tests, all passing |
| `npx tsc --noEmit` | clean |

Live seats keep the docs they spawned with, so this reaches the fleet at their next spawn after a daemon upgrade — not today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
